### PR TITLE
Add missing prefix section, other customizations

### DIFF
--- a/resources/templates/owl-core-en-only/template_variants/html/templates/layout.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/layout.html
@@ -48,6 +48,10 @@
             margin: revert !important;
         }
 
+        #printButton{
+            float: right;
+            margin-top: 0.5em;
+        }
 
         @media print {
             #toc {
@@ -55,7 +59,7 @@
             }
 
             #print-container {
-                width: 90% !important;
+                width: 100% !important;
                 position: absolute;
                 left: 0;
                 top: 0;
@@ -64,6 +68,13 @@
             footer {
                 display: none;
             }
+            #printButton {
+                visibility: hidden;
+            }
+            .dataTables_length, .dataTables_filter, .dt-buttons {
+                visibility: hidden !important;
+            }
+            @page {size: landscape !important}
         }
 
     </style>
@@ -74,7 +85,9 @@
     <div class="three wide column">
         <div id="toc"></div>
     </div>
+
     <div id="print-container" class="ten wide column">
+        <button class="ui button" id="printButton">Print report</button>
         <h1 class="ui header center aligned reportTitle" id="skip-toc">{{ conf.title }}</h1>
         {% block content %}
             < empty >
@@ -131,7 +144,7 @@
                 $(this).next().remove()
                 $(this).remove();
             });
-            $("#print-container").append("<p><strong>Datasets are identical and no differences were found</strong></p>")
+            $("#print-container").append("<p><strong>Datasets are identical and no difference was found</strong></p>")
         }
 
         $(function () {
@@ -144,6 +157,13 @@
                 highlightDefault: "true"
             });
         });
+
+        $(function () {
+            $("#printButton").click(function () {
+                $("table.display").DataTable().page.len(-1).draw()
+                window.print()
+            })
+        })
 
 
     });

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/macros.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/macros.html
@@ -27,6 +27,7 @@
 
 {% macro pandas_table(df, caption, column_labels={}) -%}
     {% if (df is defined) and (df is not none) %}
+                {% set df = df.fillna(value="") %}
         <table class="display">
             <thead class="center aligned">
             <tr>
@@ -69,4 +70,24 @@
         {% endfor %}
 
     {% endfor %}
+{% endmacro %}
+
+{% macro render_namespaces(namesapces_dist) %}
+    <table class="display">
+        <thead class="center aligned">
+        <tr>
+            <th>Namespace</th>
+            <th>URI</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for prefix, uri in namesapces_dist|dictsort %}
+            <tr>
+                <td>{{ prefix }}</td>
+                <td>{{ uri }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <caption>Prefixes</caption>
+    </table>
 {% endmacro %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/main.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/main.html
@@ -699,5 +699,9 @@
         
     
 
+    <h1>Prefixes</h1>
+    <section class="ui basic segment">
+    {{ mc.render_namespaces(namespaces.namespaces_as_dict()) }}
+    </section>
 
 {% endblock %}

--- a/resources/templates/shacl-core-en-only/template_variants/html/templates/layout.html
+++ b/resources/templates/shacl-core-en-only/template_variants/html/templates/layout.html
@@ -48,6 +48,10 @@
             margin: revert !important;
         }
 
+        #printButton{
+            float: right;
+            margin-top: 0.5em;
+        }
 
         @media print {
             #toc {
@@ -55,7 +59,7 @@
             }
 
             #print-container {
-                width: 90% !important;
+                width: 100% !important;
                 position: absolute;
                 left: 0;
                 top: 0;
@@ -64,6 +68,13 @@
             footer {
                 display: none;
             }
+            #printButton {
+                visibility: hidden;
+            }
+            .dataTables_length, .dataTables_filter, .dt-buttons {
+                visibility: hidden !important;
+            }
+            @page {size: landscape !important}
         }
 
     </style>
@@ -74,7 +85,9 @@
     <div class="three wide column">
         <div id="toc"></div>
     </div>
+
     <div id="print-container" class="ten wide column">
+        <button class="ui button" id="printButton">Print report</button>
         <h1 class="ui header center aligned reportTitle" id="skip-toc">{{ conf.title }}</h1>
         {% block content %}
             < empty >
@@ -131,7 +144,7 @@
                 $(this).next().remove()
                 $(this).remove();
             });
-            $("#print-container").append("<p><strong>Datasets are identical and no differences were found</strong></p>")
+            $("#print-container").append("<p><strong>Datasets are identical and no difference was found</strong></p>")
         }
 
         $(function () {
@@ -144,6 +157,13 @@
                 highlightDefault: "true"
             });
         });
+
+        $(function () {
+            $("#printButton").click(function () {
+                $("table.display").DataTable().page.len(-1).draw()
+                window.print()
+            })
+        })
 
 
     });

--- a/resources/templates/shacl-core-en-only/template_variants/html/templates/macros.html
+++ b/resources/templates/shacl-core-en-only/template_variants/html/templates/macros.html
@@ -27,6 +27,7 @@
 
 {% macro pandas_table(df, caption, column_labels={}) -%}
     {% if (df is defined) and (df is not none) %}
+                {% set df = df.fillna(value="") %}
         <table class="display">
             <thead class="center aligned">
             <tr>
@@ -69,4 +70,24 @@
         {% endfor %}
 
     {% endfor %}
+{% endmacro %}
+
+{% macro render_namespaces(namesapces_dist) %}
+    <table class="display">
+        <thead class="center aligned">
+        <tr>
+            <th>Namespace</th>
+            <th>URI</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for prefix, uri in namesapces_dist|dictsort %}
+            <tr>
+                <td>{{ prefix }}</td>
+                <td>{{ uri }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <caption>Prefixes</caption>
+    </table>
 {% endmacro %}

--- a/resources/templates/shacl-core-en-only/template_variants/html/templates/main.html
+++ b/resources/templates/shacl-core-en-only/template_variants/html/templates/main.html
@@ -479,5 +479,9 @@
         
     
 
+    <h1>Prefixes</h1>
+    <section class="ui basic segment">
+    {{ mc.render_namespaces(namespaces.namespaces_as_dict()) }}
+    </section>
 
 {% endblock %}


### PR DESCRIPTION
The new profiles OWL-core and SHACL-core were missing some (manual) customizations, including the namespace **Prefixes** section, as the templates were generated outputs used as-is from `diff-query-generator`.

To reproduce such customizations, one can `diff` a known good profile against the corresponding generator output (ignoring any whitespace change), e.g. for `skos-core`:

```bash
diff -wur ../diff-query-generator/output/skos-core/html resources/templates/skos-core-en-only/template_variants/html/templates > ~/rdf-differ-customizations.patch
```

This is run from the root project directory, assuming the generator project is a sibling directory, resulting in a patch file `rdf-differ-customizations.patch` in the user's home directory.

The patch can then be applied to any pristine profile by navigating into it and running `patch`, while supplying it the number of directories to strip (which in the case of HTML templates would be `3`), for example:

```bash
cd resources/templates/owl-core-en-only
patch -p3 ~/rdf-differ-customizations.patch
```

This may create `.orig` files which one should again diff just to make sure, before removing.