### PR TITLE
Guard against invalid diffs in listing view

### DIFF
--- a/rdf_differ/entrypoints/ui/templates/index.html
+++ b/rdf_differ/entrypoints/ui/templates/index.html
@@ -15,7 +15,7 @@
         </thead>
         <tbody>
         {% for dataset in datasets %}
-            {% if dataset %}
+            {% if dataset.uid %}
                 <tr>
                     <th scope="row">
                         <a href="{{ url_for('view_dataset', dataset_id=dataset.uid) }}">{{ dataset.uid }}</a>


### PR DESCRIPTION
Diff objects without `uid` raised an internal server error in the index as the view template accesses it. Such objects, along with empty ones, are created (and never cleared) by existing tests.

Empty objects are not the problem because they are already skipped by the conditional test in the template, but they should nevertheless also be cleared as part of a test teardown procedure.

In order to reproduce this, one has to run the tests with `make test` (simply running `pytest` will not create the object in question). There will be a total of three objects, one without `uid` and two empty.

To apply this fix after such a situation, one has to rebuild the image and restart the container. For some reason, any update to the template is not taken by the rendering even if it's reflected in the container.

P.S: This is only relevant for local- or filesystem volume-based setups. Native volume-based docker services would not reflect test data files in the container, provided the images are built before the tests.