### PR TITLE
Fix domain and range not appearing for OWL report

### DIFF
--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_alt_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_change_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_comment.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_definition.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_description.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_description.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_editorial_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_example.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_example.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_hidden_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_history_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_is_defined_by.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_pref_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_scope_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_class_sub_class_of.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_class_sub_class_of.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_alt_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_change_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_comment.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_definition.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_description.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_domain.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_editorial_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_example.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_hidden_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_history_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_is_defined_by.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_pref_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_range.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_scope_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_datatype_property_sub_property_of.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_alt_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_change_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_comment.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_definition.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_description.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_domain.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_editorial_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_example.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_hidden_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_history_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_is_defined_by.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_pref_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_range.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_scope_note.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_object_property_sub_property_of.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_comment.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_created.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_created.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_description.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_description.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_imports.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_imports.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_incompatible_with.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_incompatible_with.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_issued.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_issued.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_label.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_label.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_license.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_license.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_preferred_namespace_prefix.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_preferred_namespace_prefix.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_preferred_namespace_uri.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_preferred_namespace_uri.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_prior_version.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_prior_version.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_publisher.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_publisher.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_see_also.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_see_also.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_title.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_title.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_version_info.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_version_info.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_version_iri.rq
+++ b/resources/templates/owl-core-en-only/queries/count_updated_property_ontology_version_iri.rq
@@ -95,8 +95,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_alt_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_change_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_comment.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_definition.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_description.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_editorial_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_example.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_example.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_hidden_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_history_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_is_defined_by.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_pref_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_scope_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_sub_class_of.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_sub_class_of.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_alt_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_change_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_comment.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_definition.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_description.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_domain.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_editorial_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_example.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_hidden_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_history_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_is_defined_by.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_pref_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_range.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_scope_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_sub_property_of.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_alt_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_change_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_comment.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_definition.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_description.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_domain.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_editorial_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_example.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_hidden_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_history_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_is_defined_by.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_pref_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_range.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_scope_note.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_sub_property_of.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_comment.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_created.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_created.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_description.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_imports.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_imports.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_incompatible_with.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_incompatible_with.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_issued.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_issued.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_label.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_license.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_license.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_prefix.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_prefix.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_uri.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_uri.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_prior_version.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_prior_version.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_publisher.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_publisher.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_see_also.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_see_also.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_title.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_title.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_info.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_info.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_iri.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_iri.rq
@@ -114,8 +114,15 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-
-  FILTER( lang(?oldValue) = lang(?newValue) && ?oldValue != ?newValue )
-
+  FILTER (
+    (
+      # Case 1: Both values are language-tagged literals
+      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
+      ||
+      # Case 2: Both values are non-language-tagged literals or URIs
+      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
+    )
+    && ?oldValue != ?newValue
+  )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/added_instance_class.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/added_instance_class.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Added Classes</h2>
+    <h2 class="ui header">Added Classs</h2>
     <section class="ui basic segment">
         <p>The table below lists the added <strong>owl:Class</strong>
         </p>
         <p><strong>Query identifier:</strong> added_instance_class.rq</p>
-        {{ mc.pandas_table(content, "Added Classes") }}
+        {{ mc.pandas_table(content, "Added Classs") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/deleted_instance_class.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/deleted_instance_class.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Deleted Classes</h2>
+    <h2 class="ui header">Deleted Classs</h2>
     <section class="ui basic segment">
         <p>The table below lists the deleted <strong>owl:Class</strong>
         </p>
         <p><strong>Query identifier:</strong> deleted_instance_class.rq</p>
-        {{ mc.pandas_table(content, "Deleted Classes") }}
+        {{ mc.pandas_table(content, "Deleted Classs") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/added_instance_datatype_property.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/added_instance_datatype_property.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Added Datatype Properties</h2>
+    <h2 class="ui header">Added Datatype Propertys</h2>
     <section class="ui basic segment">
         <p>The table below lists the added <strong>owl:DatatypeProperty</strong>
         </p>
         <p><strong>Query identifier:</strong> added_instance_datatype_property.rq</p>
-        {{ mc.pandas_table(content, "Added Datatype Properties") }}
+        {{ mc.pandas_table(content, "Added Datatype Propertys") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/deleted_instance_datatype_property.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/deleted_instance_datatype_property.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Deleted Datatype Properties</h2>
+    <h2 class="ui header">Deleted Datatype Propertys</h2>
     <section class="ui basic segment">
         <p>The table below lists the deleted <strong>owl:DatatypeProperty</strong>
         </p>
         <p><strong>Query identifier:</strong> deleted_instance_datatype_property.rq</p>
-        {{ mc.pandas_table(content, "Deleted Datatype Properties") }}
+        {{ mc.pandas_table(content, "Deleted Datatype Propertys") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["added_property_datatype_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Added domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the added <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> added_property_datatype_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Added domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["added_property_datatype_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Added ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the added <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> added_property_datatype_property_range.rq</p>
+    {{ mc.pandas_table(content, "Added range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["changed_property_datatype_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Changed domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the changed <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> changed_property_datatype_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Changed domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["changed_property_datatype_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Changed ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the changed <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> changed_property_datatype_property_range.rq</p>
+    {{ mc.pandas_table(content, "Changed range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["deleted_property_datatype_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Deleted domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the deleted <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> deleted_property_datatype_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Deleted domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["deleted_property_datatype_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Deleted ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the deleted <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> deleted_property_datatype_property_range.rq</p>
+    {{ mc.pandas_table(content, "Deleted range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["moved_property_datatype_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Moved domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the moved <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> moved_property_datatype_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Moved domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["moved_property_datatype_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Moved ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the moved <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> moved_property_datatype_property_range.rq</p>
+    {{ mc.pandas_table(content, "Moved range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["updated_property_datatype_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Updated domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the updated <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> updated_property_datatype_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Updated domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["updated_property_datatype_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Updated ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the updated <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> updated_property_datatype_property_range.rq</p>
+    {{ mc.pandas_table(content, "Updated range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/layout.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/layout.html
@@ -48,10 +48,6 @@
             margin: revert !important;
         }
 
-        #printButton{
-            float: right;
-            margin-top: 0.5em;
-        }
 
         @media print {
             #toc {
@@ -59,7 +55,7 @@
             }
 
             #print-container {
-                width: 100% !important;
+                width: 90% !important;
                 position: absolute;
                 left: 0;
                 top: 0;
@@ -68,13 +64,6 @@
             footer {
                 display: none;
             }
-            #printButton {
-                visibility: hidden;
-            }
-            .dataTables_length, .dataTables_filter, .dt-buttons {
-                visibility: hidden !important;
-            }
-            @page {size: landscape !important}
         }
 
     </style>
@@ -85,9 +74,7 @@
     <div class="three wide column">
         <div id="toc"></div>
     </div>
-
     <div id="print-container" class="ten wide column">
-        <button class="ui button" id="printButton">Print report</button>
         <h1 class="ui header center aligned reportTitle" id="skip-toc">{{ conf.title }}</h1>
         {% block content %}
             < empty >
@@ -144,7 +131,7 @@
                 $(this).next().remove()
                 $(this).remove();
             });
-            $("#print-container").append("<p><strong>Datasets are identical and no difference was found</strong></p>")
+            $("#print-container").append("<p><strong>Datasets are identical and no differences were found</strong></p>")
         }
 
         $(function () {
@@ -157,13 +144,6 @@
                 highlightDefault: "true"
             });
         });
-
-        $(function () {
-            $("#printButton").click(function () {
-                $("table.display").DataTable().page.len(-1).draw()
-                window.print()
-            })
-        })
 
 
     });

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/macros.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/macros.html
@@ -27,46 +27,38 @@
 
 {% macro pandas_table(df, caption, column_labels={}) -%}
     {% if (df is defined) and (df is not none) %}
-        {% set df = df.fillna(value="") %}
         <table class="display">
             <thead class="center aligned">
+            <tr>
+                {% for column in df.columns %}
+                    {% if column in column_labels %}
+                        <th>{{ column_labels[column] }}</th>
+                    {% else %}
+                        <th>{{ column }}</th>
+                    {% endif %}
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for idx, row in df.iterrows() %}
                 <tr>
-                    {% for column in df.columns %}
-                        {% if not (column.endswith('Lang') or column == 'actionType') %}
-                            <th>{{ column_labels.get(column, column) }}</th>
+                    {% for colname in df.columns %}
+                        {# handle decimal format: float, float64, float32 #}
+                        {% if 'float' in (df.dtypes[colname] | string) %}
+                            <td class="left aligned collapsing">{{ row[colname] | round(precision=2) }}</td>
+                        {% else %}
+                            <td>{{ row[colname] }}</td>
                         {% endif %}
                     {% endfor %}
                 </tr>
-            </thead>
-            <tbody>
-                {% for idx, row in df.iterrows() %}
-                    <tr>
-                        {% for colname in df.columns %}
-                            {% if not (colname.endswith('Lang') or colname == 'actionType') %}
-                                {# handle decimal format: float, float64, float32 #}
-                                {% if 'float' in (df.dtypes[colname] | string) %}
-                                    <td class="left aligned collapsing">{{ row[colname] | round(precision=2) }}</td>
-                                {% else %}
-                                    {% set lang_colname = colname ~ 'Lang' %}
-                                    {% if lang_colname in df.columns and row[lang_colname] != '' %}
-                                        <td>{{ row[colname] ~ '@' ~ row[lang_colname] }}</td>
-                                    {% else %}
-                                        <td>{{ row[colname] }}</td>
-                                    {% endif %}
-                                {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
+            {% endfor %}
             </tbody>
             <caption>{{ caption }}</caption>
         </table>
     {% else %}
-        {{ render_error("How did you get here? Did you forget to use 'render_fetch_results' macro?") }}
+        {{ render_error("How did you get here? did you forget to use 'render_fetch_results' macro?") }}
     {% endif %}
 {%- endmacro %}
-
-
 
 {% macro count_value(df) %}
     {% for idx, row in df.iterrows() %}
@@ -77,24 +69,4 @@
         {% endfor %}
 
     {% endfor %}
-{% endmacro %}
-
-{% macro render_namespaces(namesapces_dist) %}
-    <table class="display">
-        <thead class="center aligned">
-        <tr>
-            <th>Namespace</th>
-            <th>URI</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for prefix, uri in namesapces_dist|dictsort %}
-            <tr>
-                <td>{{ prefix }}</td>
-                <td>{{ uri }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-        <caption>Prefixes</caption>
-    </table>
 {% endmacro %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/main.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/main.html
@@ -4,7 +4,7 @@
 {% block content %}
 
     <p>This report is automatically generated from the {{ conf.dataset_name }} RDF dataset on <time>{{ conf.timestamp }}</time>
-        and aims at presenting the difference between two versions of an RDFS/OWL ontology following the {{ conf.application_profile }} application profile.</p>
+        and aims at presenting the difference between two versions of an RDFS/OWL vocabulary following the {{ conf.application_profile }} application profile.</p>
     <p>Report details</p>
     <p><strong>Dataset ID: </strong> {{ conf.dataset_name }}</p>
     <p><strong>Dataset name: </strong> {{ conf.original_name }}</p>
@@ -532,6 +532,26 @@
         
             {% include "objectproperty/semantic_properties/changed_property_object_property_is_defined_by.html" with context %}
         
+            {% include "objectproperty/semantic_properties/added_property_object_property_domain.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/deleted_property_object_property_domain.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/updated_property_object_property_domain.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/moved_property_object_property_domain.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/changed_property_object_property_domain.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/added_property_object_property_range.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/deleted_property_object_property_range.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/updated_property_object_property_range.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/moved_property_object_property_range.html" with context %}
+        
+            {% include "objectproperty/semantic_properties/changed_property_object_property_range.html" with context %}
+        
     
 
     <h1>Datatype Property</h1>
@@ -700,11 +720,27 @@
         
             {% include "datatypeproperty/semantic_properties/changed_property_datatype_property_is_defined_by.html" with context %}
         
+            {% include "datatypeproperty/semantic_properties/added_property_datatype_property_domain.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/deleted_property_datatype_property_domain.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/updated_property_datatype_property_domain.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/moved_property_datatype_property_domain.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/changed_property_datatype_property_domain.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/added_property_datatype_property_range.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/deleted_property_datatype_property_range.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/updated_property_datatype_property_range.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/moved_property_datatype_property_range.html" with context %}
+        
+            {% include "datatypeproperty/semantic_properties/changed_property_datatype_property_range.html" with context %}
+        
     
 
-    <h1>Prefixes</h1>
-    <section class="ui basic segment">
-    {{ mc.render_namespaces(namespaces.namespaces_as_dict()) }}
-    </section>
 
 {% endblock %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/added_instance_object_property.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/added_instance_object_property.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Added Object Properties</h2>
+    <h2 class="ui header">Added Object Propertys</h2>
     <section class="ui basic segment">
         <p>The table below lists the added <strong>owl:ObjectProperty</strong>
         </p>
         <p><strong>Query identifier:</strong> added_instance_object_property.rq</p>
-        {{ mc.pandas_table(content, "Added Object Properties") }}
+        {{ mc.pandas_table(content, "Added Object Propertys") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/deleted_instance_object_property.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/deleted_instance_object_property.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Deleted Object Properties</h2>
+    <h2 class="ui header">Deleted Object Propertys</h2>
     <section class="ui basic segment">
         <p>The table below lists the deleted <strong>owl:ObjectProperty</strong>
         </p>
         <p><strong>Query identifier:</strong> deleted_instance_object_property.rq</p>
-        {{ mc.pandas_table(content, "Deleted Object Properties") }}
+        {{ mc.pandas_table(content, "Deleted Object Propertys") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["added_property_object_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Added domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the added <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> added_property_object_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Added domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["added_property_object_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Added ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the added <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> added_property_object_property_range.rq</p>
+    {{ mc.pandas_table(content, "Added range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["changed_property_object_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Changed domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the changed <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> changed_property_object_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Changed domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["changed_property_object_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Changed ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the changed <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> changed_property_object_property_range.rq</p>
+    {{ mc.pandas_table(content, "Changed range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["deleted_property_object_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Deleted domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the deleted <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> deleted_property_object_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Deleted domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["deleted_property_object_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Deleted ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the deleted <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> deleted_property_object_property_range.rq</p>
+    {{ mc.pandas_table(content, "Deleted range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["moved_property_object_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Moved domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the moved <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> moved_property_object_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Moved domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["moved_property_object_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Moved ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the moved <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> moved_property_object_property_range.rq</p>
+    {{ mc.pandas_table(content, "Moved range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_domain.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["updated_property_object_property_domain.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Updated domains</h3>
+<section class="ui basic segment">
+    <p>The table below lists the updated <strong>rdfs:domain</strong>
+    </p>
+    <p><strong>Query identifier:</strong> updated_property_object_property_domain.rq</p>
+    {{ mc.pandas_table(content, "Updated domain") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_range.html
@@ -1,0 +1,20 @@
+
+{% import "macros.html" as mc %}
+
+    {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["updated_property_object_property_range.rq"]).fetch_tabular() %}
+    
+{% if not content.empty %}
+    {% call mc.render_fetch_results(content, error) %}
+    {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
+    
+<h3 class="ui header">Updated ranges</h3>
+<section class="ui basic segment">
+    <p>The table below lists the updated <strong>rdfs:range</strong>
+    </p>
+    <p><strong>Query identifier:</strong> updated_property_object_property_range.rq</p>
+    {{ mc.pandas_table(content, "Updated range") }}
+</section>
+    
+    {% endcall %}
+{% endif %}
+    

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/added_instance_ontology.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/added_instance_ontology.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Added Ontologies</h2>
+    <h2 class="ui header">Added Ontologys</h2>
     <section class="ui basic segment">
         <p>The table below lists the added <strong>owl:Ontology</strong>
         </p>
         <p><strong>Query identifier:</strong> added_instance_ontology.rq</p>
-        {{ mc.pandas_table(content, "Added Ontologies") }}
+        {{ mc.pandas_table(content, "Added Ontologys") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/deleted_instance_ontology.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/deleted_instance_ontology.html
@@ -7,12 +7,12 @@
    {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-    <h2 class="ui header">Deleted Ontologies</h2>
+    <h2 class="ui header">Deleted Ontologys</h2>
     <section class="ui basic segment">
         <p>The table below lists the deleted <strong>owl:Ontology</strong>
         </p>
         <p><strong>Query identifier:</strong> deleted_instance_ontology.rq</p>
-        {{ mc.pandas_table(content, "Deleted Ontologies") }}
+        {{ mc.pandas_table(content, "Deleted Ontologys") }}
     </section>
     
     {% endcall %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/statistics.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/statistics.html
@@ -2396,6 +2396,102 @@
                     </tr>
 
                 
+
+                    <tr>
+                        <td>Semantic Properties</td>
+                        <td>rdfs:domain</td>
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_added_property_object_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_deleted_property_object_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_updated_property_object_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_moved_property_object_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_changed_property_object_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                    </tr>
+
+                
+
+                    <tr>
+                        <td>Semantic Properties</td>
+                        <td>rdfs:range</td>
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_added_property_object_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_deleted_property_object_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_updated_property_object_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_moved_property_object_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_changed_property_object_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                    </tr>
+
+                
             
             </tbody>
         </table>
@@ -3168,6 +3264,102 @@
                             
                         
                             {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_changed_property_datatype_property_is_defined_by.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                    </tr>
+
+                
+
+                    <tr>
+                        <td>Semantic Properties</td>
+                        <td>rdfs:domain</td>
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_added_property_datatype_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_deleted_property_datatype_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_updated_property_datatype_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_moved_property_datatype_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_changed_property_datatype_property_domain.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                    </tr>
+
+                
+
+                    <tr>
+                        <td>Semantic Properties</td>
+                        <td>rdfs:range</td>
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_added_property_datatype_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_deleted_property_datatype_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_updated_property_datatype_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_moved_property_datatype_property_range.rq"]).fetch_tabular() %}
+                            
+                            {% call mc.render_fetch_results(content, error) %}
+
+                            {{ mc.count_value(content) }}
+                            {% endcall %}
+                            
+                        
+                            {% set content, error = from_endpoint(conf.default_endpoint).with_query_from_file(conf.query_files["count_changed_property_datatype_property_range.rq"]).fetch_tabular() %}
                             
                             {% call mc.render_fetch_results(content, error) %}
 


### PR DESCRIPTION
Ever since adding support for the OWL Core profile, in particular semantic properties like `rdfs:domain` and `rdfs:range`, it has gone unnoticed that changes related to these properties do not come up. This was because in the corresponding queries there was a filter to check if the language is the same for both the old and new data.

A more intricate query has been put in place in order to cater for when there is no scope for such language tags to exist. However, it is not known at this time why this is required in the first place. It needs to be checked what is in fact the effect of having a different language tag, or no language tag to a language tag, and vice-versa.

Integration of https://github.com/meaningfy-ws/diff-query-generator/pull/29.