### PR TITLE
Resolve test container conflicts, update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,17 +141,25 @@ else
 	false
 endif
 
+teardown-services:
+ifeq ($(OS_DOCKERC), 1)
+	@ echo -e '$(BUILD_PRINT)Tearing down the microservice environment'
+	@ docker compose -p rdf-differ-${ENVIRONMENT} --file docker/docker-compose.yml --env-file docker/.env down --volumes --remove-orphans
+else
+	@ echo "$(MSG_PRINT)Docker not found, please see README"
+	false
+endif
 
 #-----------------------------------------------------------------------------
 # Fuseki control for github actions
 #-----------------------------------------------------------------------------
 setup-docker-fuseki: | build-volumes
 	@ echo -e '$(BUILD_PRINT)Building the Fuseki service'
-	@ docker compose --file docker/docker-compose-tests.yml --env-file docker/.env build rdf-differ-fuseki
+	@ docker compose -p rdf-differ-${ENVIRONMENT} --file docker/docker-compose-tests.yml --env-file docker/.env build rdf-differ-fuseki
 
 run-docker-fuseki:
 	@ echo -e '$(BUILD_PRINT)Starting the Fuseki service'
-	@ docker compose --file docker/docker-compose-tests.yml --env-file docker/.env up -d rdf-differ-fuseki
+	@ docker compose -p rdf-differ-${ENVIRONMENT} --file docker/docker-compose-tests.yml --env-file docker/.env up -d rdf-differ-fuseki
 
 #-----------------------------------------------------------------------------
 # Test commands
@@ -165,11 +173,11 @@ test-data-fuseki: | setup-docker-fuseki run-docker-fuseki
 
 run-docker-redis:
 	@ echo -e '$(BUILD_PRINT)Starting redis'
-	@ docker compose --file docker/docker-compose-tests.yml --env-file docker/.env up -d rdf-differ-redis
+	@ docker compose -p rdf-differ-${ENVIRONMENT} --file docker/docker-compose-tests.yml --env-file docker/.env up -d rdf-differ-redis
 
 run-docker-api:
 	@ echo -e '$(BUILD_PRINT)Starting api'
-	@ docker compose --file docker/docker-compose-tests.yml --env-file docker/.env up -d rdf-differ-api
+	@ docker compose -p rdf-differ-${ENVIRONMENT} --file docker/docker-compose-tests.yml --env-file docker/.env up -d rdf-differ-api
 
 run-docker-ui:
 	@ echo -e '$(BUILD_PRINT)Starting ui'

--- a/README.md
+++ b/README.md
@@ -147,14 +147,19 @@ make run-local-fuseki
 ## Testing
 
 The test suite spins up certain duplicate docker services _without_ traefik, so
-access to those specific services are directly through the localhost and respective
-ports. Run the following to run everything:
+access to those specific services are directly through the localhost and
+respective ports. Run the following to start everything and also remove the
+duplicate testing containers at the end:
 
 ```bash
-make test
+make ENVIRONMENT=test test teardown-services
 ```
 
-This creates the `subdiv` and `abc` dummy datasets once in the running fuseki service, and a `dataset{ID}` dataset (where `{ID}` is a short random ID) as many times as the tests are run. The `db` folder is populated by the tests.
+This creates the `subdiv` and `abc` dummy datasets once in a new fuseki
+container, and a `dataset{ID}` dataset (where `{ID}` is a short random ID) as
+many times as the tests are run. The `db` folder is populated by the tests and
+it is _not_ removed automatically. Omit `teardown-services` if you want to
+inspect the test containers for any reason after the tests complete.
 
 ## Adding a new Application Profile template
 For adding a new Application Profile (AP) create a new folder under [resources/templates](resources/templates) with the name


### PR DESCRIPTION
Include the ENVIRONMENT variable and project argument for the docker services specifically used for testing. This avoids conflict with the local or prod containers. Add also a teardown target to remove all containers, which is useful for the testing target.