### PR TITLE
Fix elusive Turtle file load issue due to cURL -d and comments

### DIFF
--- a/resources/load_versions.sh
+++ b/resources/load_versions.sh
@@ -68,7 +68,7 @@ sparql_put()
     echo "$file does not exist"
     exit 1
   fi
-  curl --silent -X PUT -H "Content-Type: $INPUT_MIME_TYPE" -d @$file $PUT_URI?graph=$graph > /dev/null
+  curl --silent -X PUT -H "Content-Type: $INPUT_MIME_TYPE" --data-binary @$file $PUT_URI?graph=$graph > /dev/null
   local status=$?
   if [ $status -ne 0 ]; then
     echo "\nPUT for file $file failed with status $status"


### PR DESCRIPTION
This is one of those hair-pulling issues that end up being one-line fixes. Several example files were not producing expected diff reports, including those that had comments in the new version of the file to explain changes.

It turns out that skos-history's use of `curl -d` in `load-versions.sh` is dangerous for sending RDF files to a server, as comments could be interpreted and lines discarded. It just so happens that Turtle syntax has Bash-style `#` comment markers, and all content after the first comment gets thrown away. The original developers may have not been too aware of Turtle at the time, which is understandable.

What then gets into the triplestore is a confusing state of affairs. Depending on where the first comment is, one will see certain triples and not others. The solution, aside from avoiding comments in Turtle files (and possibly other serializations), is to use `--data-binary` in the cURL command.

P.S: It looks like a migration of the aging `load-versions.sh` Bash script to a proper Python one is in order, as previously anticipated but never materialized/prioritized. This issue proves that shell scripts can be really brittle and a lot of things can go wrong unexpectedly.