### PR TITLE
Fix support for OWL, TRIG extensions, fix TRIX

### DIFF
--- a/rdf_differ/utils/file_utils.py
+++ b/rdf_differ/utils/file_utils.py
@@ -157,7 +157,9 @@ def temporarily_save_files(old_file: FileStorage, new_file: FileStorage):
 
 INPUT_MIME_TYPES = {
     'rdf': 'application/rdf+xml',
-    'trix': 'application/xml',
+    'owl': 'application/rdf+xml',
+    'trix': 'application/trix',
+    "trig": "application/trig",
     'nq': 'application/n-quads',
     'nt': 'application/n-triples',
     'jsonld': 'application/ld+json',

--- a/tests/unit/test_skos_history_wrapper.py
+++ b/tests/unit/test_skos_history_wrapper.py
@@ -15,7 +15,9 @@ from tests.conftest import helper_create_skos_runner
 
 
 @pytest.mark.parametrize("filename, file_format", [('test.rdf', 'application/rdf+xml'),
-                                                   ('test.trix', 'application/xml'),
+                                                   ('test.owl', 'application/rdf+xml'),
+                                                   ('test.trix', 'application/trix'),
+                                                   ('test.trig', 'application/trig'),
                                                    ('test.nq', 'application/n-quads'),
                                                    ('test.nt', 'application/n-triples'),
                                                    ('test.ttl', 'text/turtle'),
@@ -46,7 +48,7 @@ def test_file_formats_different():
     with pytest.raises(Exception) as exception:
         _ = helper_create_skos_runner(old_version_file='old.rdf', new_version_file='new.trix')
 
-    assert 'File formats are different: application/rdf+xml, application/xml' in str(exception.value)
+    assert 'File formats are different: application/rdf+xml, application/trix' in str(exception.value)
 
 
 def test_uris_creation():


### PR DESCRIPTION
The `.owl` extension is common for ontologies using the OWL-flavour of RDF/XML. Such files normally do work by renaming them to `.rdf` but it is useful to have direct support for the OWL one.

The `trix` MIME TYPE does not look like what is being documented on the web currently, so it has been updated accordingly to be `application/trig` instead of `text/xml`.

See https://graphdb.ontotext.com/documentation/11.1/rdf-formats.html#rdf-json