### PR TITLE
Reports: Remove crude section name pluralization

### DIFF
--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added alt labels</h3>
+<h3 class="ui header">Added alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added hidden labels</h3>
+<h3 class="ui header">Added hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added labels</h3>
+<h3 class="ui header">Added label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/added_property_class_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added pref labels</h3>
+<h3 class="ui header">Added pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed alt labels</h3>
+<h3 class="ui header">Changed alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed hidden labels</h3>
+<h3 class="ui header">Changed hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed labels</h3>
+<h3 class="ui header">Changed label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/changed_property_class_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed pref labels</h3>
+<h3 class="ui header">Changed pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted alt labels</h3>
+<h3 class="ui header">Deleted alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted hidden labels</h3>
+<h3 class="ui header">Deleted hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted labels</h3>
+<h3 class="ui header">Deleted label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/deleted_property_class_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted pref labels</h3>
+<h3 class="ui header">Deleted pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved alt labels</h3>
+<h3 class="ui header">Moved alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved hidden labels</h3>
+<h3 class="ui header">Moved hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved labels</h3>
+<h3 class="ui header">Moved label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/moved_property_class_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved pref labels</h3>
+<h3 class="ui header">Moved pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated alt labels</h3>
+<h3 class="ui header">Updated alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated hidden labels</h3>
+<h3 class="ui header">Updated hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated labels</h3>
+<h3 class="ui header">Updated label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/labels/updated_property_class_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated pref labels</h3>
+<h3 class="ui header">Updated pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added change notes</h3>
+<h3 class="ui header">Added change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added comments</h3>
+<h3 class="ui header">Added comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added definitions</h3>
+<h3 class="ui header">Added definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added descriptions</h3>
+<h3 class="ui header">Added description</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added editorial notes</h3>
+<h3 class="ui header">Added editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added examples</h3>
+<h3 class="ui header">Added example</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added history notes</h3>
+<h3 class="ui header">Added history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added notes</h3>
+<h3 class="ui header">Added note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/added_property_class_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added scope notes</h3>
+<h3 class="ui header">Added scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed change notes</h3>
+<h3 class="ui header">Changed change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed comments</h3>
+<h3 class="ui header">Changed comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed definitions</h3>
+<h3 class="ui header">Changed definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed descriptions</h3>
+<h3 class="ui header">Changed description</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed editorial notes</h3>
+<h3 class="ui header">Changed editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed examples</h3>
+<h3 class="ui header">Changed example</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed history notes</h3>
+<h3 class="ui header">Changed history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed notes</h3>
+<h3 class="ui header">Changed note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/changed_property_class_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed scope notes</h3>
+<h3 class="ui header">Changed scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted change notes</h3>
+<h3 class="ui header">Deleted change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted comments</h3>
+<h3 class="ui header">Deleted comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted definitions</h3>
+<h3 class="ui header">Deleted definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted descriptions</h3>
+<h3 class="ui header">Deleted description</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted editorial notes</h3>
+<h3 class="ui header">Deleted editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted examples</h3>
+<h3 class="ui header">Deleted example</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted history notes</h3>
+<h3 class="ui header">Deleted history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted notes</h3>
+<h3 class="ui header">Deleted note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/deleted_property_class_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted scope notes</h3>
+<h3 class="ui header">Deleted scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved change notes</h3>
+<h3 class="ui header">Moved change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved comments</h3>
+<h3 class="ui header">Moved comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved definitions</h3>
+<h3 class="ui header">Moved definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved descriptions</h3>
+<h3 class="ui header">Moved description</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved editorial notes</h3>
+<h3 class="ui header">Moved editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved examples</h3>
+<h3 class="ui header">Moved example</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved history notes</h3>
+<h3 class="ui header">Moved history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved notes</h3>
+<h3 class="ui header">Moved note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/moved_property_class_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved scope notes</h3>
+<h3 class="ui header">Moved scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated change notes</h3>
+<h3 class="ui header">Updated change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated comments</h3>
+<h3 class="ui header">Updated comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated definitions</h3>
+<h3 class="ui header">Updated definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated descriptions</h3>
+<h3 class="ui header">Updated description</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated editorial notes</h3>
+<h3 class="ui header">Updated editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated examples</h3>
+<h3 class="ui header">Updated example</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated history notes</h3>
+<h3 class="ui header">Updated history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated notes</h3>
+<h3 class="ui header">Updated note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/notes/updated_property_class_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated scope notes</h3>
+<h3 class="ui header">Updated scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/added_property_class_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/added_property_class_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added is defined bys</h3>
+<h3 class="ui header">Added is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/added_property_class_sub_class_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/added_property_class_sub_class_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added sub class ofs</h3>
+<h3 class="ui header">Added sub class of</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:subClassOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/changed_property_class_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/changed_property_class_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed is defined bys</h3>
+<h3 class="ui header">Changed is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/changed_property_class_sub_class_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/changed_property_class_sub_class_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed sub class ofs</h3>
+<h3 class="ui header">Changed sub class of</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:subClassOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/deleted_property_class_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/deleted_property_class_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted is defined bys</h3>
+<h3 class="ui header">Deleted is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/deleted_property_class_sub_class_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/deleted_property_class_sub_class_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted sub class ofs</h3>
+<h3 class="ui header">Deleted sub class of</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:subClassOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/moved_property_class_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/moved_property_class_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved is defined bys</h3>
+<h3 class="ui header">Moved is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/moved_property_class_sub_class_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/moved_property_class_sub_class_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved sub class ofs</h3>
+<h3 class="ui header">Moved sub class of</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:subClassOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/updated_property_class_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/updated_property_class_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated is defined bys</h3>
+<h3 class="ui header">Updated is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/updated_property_class_sub_class_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/class/semantic_properties/updated_property_class_sub_class_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated sub class ofs</h3>
+<h3 class="ui header">Updated sub class of</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:subClassOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added alt labels</h3>
+<h3 class="ui header">Added alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added hidden labels</h3>
+<h3 class="ui header">Added hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added labels</h3>
+<h3 class="ui header">Added label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/added_property_datatype_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added pref labels</h3>
+<h3 class="ui header">Added pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed alt labels</h3>
+<h3 class="ui header">Changed alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed hidden labels</h3>
+<h3 class="ui header">Changed hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed labels</h3>
+<h3 class="ui header">Changed label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/changed_property_datatype_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed pref labels</h3>
+<h3 class="ui header">Changed pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted alt labels</h3>
+<h3 class="ui header">Deleted alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted hidden labels</h3>
+<h3 class="ui header">Deleted hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted labels</h3>
+<h3 class="ui header">Deleted label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/deleted_property_datatype_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted pref labels</h3>
+<h3 class="ui header">Deleted pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved alt labels</h3>
+<h3 class="ui header">Moved alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved hidden labels</h3>
+<h3 class="ui header">Moved hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved labels</h3>
+<h3 class="ui header">Moved label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/moved_property_datatype_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved pref labels</h3>
+<h3 class="ui header">Moved pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated alt labels</h3>
+<h3 class="ui header">Updated alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated hidden labels</h3>
+<h3 class="ui header">Updated hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated labels</h3>
+<h3 class="ui header">Updated label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/labels/updated_property_datatype_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated pref labels</h3>
+<h3 class="ui header">Updated pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added change notes</h3>
+<h3 class="ui header">Added change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added comments</h3>
+<h3 class="ui header">Added comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added definitions</h3>
+<h3 class="ui header">Added definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added descriptions</h3>
+<h3 class="ui header">Added description</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added editorial notes</h3>
+<h3 class="ui header">Added editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added examples</h3>
+<h3 class="ui header">Added example</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added history notes</h3>
+<h3 class="ui header">Added history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added notes</h3>
+<h3 class="ui header">Added note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/added_property_datatype_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added scope notes</h3>
+<h3 class="ui header">Added scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed change notes</h3>
+<h3 class="ui header">Changed change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed comments</h3>
+<h3 class="ui header">Changed comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed definitions</h3>
+<h3 class="ui header">Changed definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed descriptions</h3>
+<h3 class="ui header">Changed description</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed editorial notes</h3>
+<h3 class="ui header">Changed editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed examples</h3>
+<h3 class="ui header">Changed example</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed history notes</h3>
+<h3 class="ui header">Changed history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed notes</h3>
+<h3 class="ui header">Changed note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/changed_property_datatype_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed scope notes</h3>
+<h3 class="ui header">Changed scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted change notes</h3>
+<h3 class="ui header">Deleted change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted comments</h3>
+<h3 class="ui header">Deleted comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted definitions</h3>
+<h3 class="ui header">Deleted definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted descriptions</h3>
+<h3 class="ui header">Deleted description</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted editorial notes</h3>
+<h3 class="ui header">Deleted editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted examples</h3>
+<h3 class="ui header">Deleted example</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted history notes</h3>
+<h3 class="ui header">Deleted history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted notes</h3>
+<h3 class="ui header">Deleted note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/deleted_property_datatype_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted scope notes</h3>
+<h3 class="ui header">Deleted scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved change notes</h3>
+<h3 class="ui header">Moved change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved comments</h3>
+<h3 class="ui header">Moved comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved definitions</h3>
+<h3 class="ui header">Moved definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved descriptions</h3>
+<h3 class="ui header">Moved description</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved editorial notes</h3>
+<h3 class="ui header">Moved editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved examples</h3>
+<h3 class="ui header">Moved example</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved history notes</h3>
+<h3 class="ui header">Moved history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved notes</h3>
+<h3 class="ui header">Moved note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/moved_property_datatype_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved scope notes</h3>
+<h3 class="ui header">Moved scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated change notes</h3>
+<h3 class="ui header">Updated change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated comments</h3>
+<h3 class="ui header">Updated comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated definitions</h3>
+<h3 class="ui header">Updated definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated descriptions</h3>
+<h3 class="ui header">Updated description</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated editorial notes</h3>
+<h3 class="ui header">Updated editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated examples</h3>
+<h3 class="ui header">Updated example</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated history notes</h3>
+<h3 class="ui header">Updated history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated notes</h3>
+<h3 class="ui header">Updated note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/notes/updated_property_datatype_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated scope notes</h3>
+<h3 class="ui header">Updated scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added domains</h3>
+<h3 class="ui header">Added domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added is defined bys</h3>
+<h3 class="ui header">Added is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added ranges</h3>
+<h3 class="ui header">Added range</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/added_property_datatype_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added sub property ofs</h3>
+<h3 class="ui header">Added sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed domains</h3>
+<h3 class="ui header">Changed domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed is defined bys</h3>
+<h3 class="ui header">Changed is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed ranges</h3>
+<h3 class="ui header">Changed range</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/changed_property_datatype_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed sub property ofs</h3>
+<h3 class="ui header">Changed sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted domains</h3>
+<h3 class="ui header">Deleted domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted is defined bys</h3>
+<h3 class="ui header">Deleted is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted ranges</h3>
+<h3 class="ui header">Deleted range</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/deleted_property_datatype_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted sub property ofs</h3>
+<h3 class="ui header">Deleted sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved domains</h3>
+<h3 class="ui header">Moved domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved is defined bys</h3>
+<h3 class="ui header">Moved is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved ranges</h3>
+<h3 class="ui header">Moved range</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/moved_property_datatype_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved sub property ofs</h3>
+<h3 class="ui header">Moved sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated domains</h3>
+<h3 class="ui header">Updated domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated is defined bys</h3>
+<h3 class="ui header">Updated is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated ranges</h3>
+<h3 class="ui header">Updated range</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/datatypeproperty/semantic_properties/updated_property_datatype_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated sub property ofs</h3>
+<h3 class="ui header">Updated sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/macros.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/macros.html
@@ -27,46 +27,39 @@
 
 {% macro pandas_table(df, caption, column_labels={}) -%}
     {% if (df is defined) and (df is not none) %}
-        {% set df = df.fillna(value="") %}
+                {% set df = df.fillna(value="") %}
         <table class="display">
             <thead class="center aligned">
+            <tr>
+                {% for column in df.columns %}
+                    {% if column in column_labels %}
+                        <th>{{ column_labels[column] }}</th>
+                    {% else %}
+                        <th>{{ column }}</th>
+                    {% endif %}
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for idx, row in df.iterrows() %}
                 <tr>
-                    {% for column in df.columns %}
-                        {% if not (column.endswith('Lang') or column == 'actionType') %}
-                            <th>{{ column_labels.get(column, column) }}</th>
+                    {% for colname in df.columns %}
+                        {# handle decimal format: float, float64, float32 #}
+                        {% if 'float' in (df.dtypes[colname] | string) %}
+                            <td class="left aligned collapsing">{{ row[colname] | round(precision=2) }}</td>
+                        {% else %}
+                            <td>{{ row[colname] }}</td>
                         {% endif %}
                     {% endfor %}
                 </tr>
-            </thead>
-            <tbody>
-                {% for idx, row in df.iterrows() %}
-                    <tr>
-                        {% for colname in df.columns %}
-                            {% if not (colname.endswith('Lang') or colname == 'actionType') %}
-                                {# handle decimal format: float, float64, float32 #}
-                                {% if 'float' in (df.dtypes[colname] | string) %}
-                                    <td class="left aligned collapsing">{{ row[colname] | round(precision=2) }}</td>
-                                {% else %}
-                                    {% set lang_colname = colname ~ 'Lang' %}
-                                    {% if lang_colname in df.columns and row[lang_colname] != '' %}
-                                        <td>{{ row[colname] ~ '@' ~ row[lang_colname] }}</td>
-                                    {% else %}
-                                        <td>{{ row[colname] }}</td>
-                                    {% endif %}
-                                {% endif %}
-                            {% endif %}
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
+            {% endfor %}
             </tbody>
             <caption>{{ caption }}</caption>
         </table>
     {% else %}
-        {{ render_error("How did you get here? Did you forget to use 'render_fetch_results' macro?") }}
+        {{ render_error("How did you get here? did you forget to use 'render_fetch_results' macro?") }}
     {% endif %}
 {%- endmacro %}
-
-
 
 {% macro count_value(df) %}
     {% for idx, row in df.iterrows() %}

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added alt labels</h3>
+<h3 class="ui header">Added alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added hidden labels</h3>
+<h3 class="ui header">Added hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added labels</h3>
+<h3 class="ui header">Added label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/added_property_object_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added pref labels</h3>
+<h3 class="ui header">Added pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed alt labels</h3>
+<h3 class="ui header">Changed alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed hidden labels</h3>
+<h3 class="ui header">Changed hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed labels</h3>
+<h3 class="ui header">Changed label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/changed_property_object_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed pref labels</h3>
+<h3 class="ui header">Changed pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted alt labels</h3>
+<h3 class="ui header">Deleted alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted hidden labels</h3>
+<h3 class="ui header">Deleted hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted labels</h3>
+<h3 class="ui header">Deleted label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/deleted_property_object_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted pref labels</h3>
+<h3 class="ui header">Deleted pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved alt labels</h3>
+<h3 class="ui header">Moved alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved hidden labels</h3>
+<h3 class="ui header">Moved hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved labels</h3>
+<h3 class="ui header">Moved label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/moved_property_object_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved pref labels</h3>
+<h3 class="ui header">Moved pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_alt_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_alt_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated alt labels</h3>
+<h3 class="ui header">Updated alt label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:altLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_hidden_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_hidden_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated hidden labels</h3>
+<h3 class="ui header">Updated hidden label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:hiddenLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated labels</h3>
+<h3 class="ui header">Updated label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_pref_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/labels/updated_property_object_property_pref_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated pref labels</h3>
+<h3 class="ui header">Updated pref label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:prefLabel</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added change notes</h3>
+<h3 class="ui header">Added change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added comments</h3>
+<h3 class="ui header">Added comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added definitions</h3>
+<h3 class="ui header">Added definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added descriptions</h3>
+<h3 class="ui header">Added description</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added editorial notes</h3>
+<h3 class="ui header">Added editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added examples</h3>
+<h3 class="ui header">Added example</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added history notes</h3>
+<h3 class="ui header">Added history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added notes</h3>
+<h3 class="ui header">Added note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/added_property_object_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added scope notes</h3>
+<h3 class="ui header">Added scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed change notes</h3>
+<h3 class="ui header">Changed change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed comments</h3>
+<h3 class="ui header">Changed comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed definitions</h3>
+<h3 class="ui header">Changed definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed descriptions</h3>
+<h3 class="ui header">Changed description</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed editorial notes</h3>
+<h3 class="ui header">Changed editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed examples</h3>
+<h3 class="ui header">Changed example</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed history notes</h3>
+<h3 class="ui header">Changed history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed notes</h3>
+<h3 class="ui header">Changed note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/changed_property_object_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed scope notes</h3>
+<h3 class="ui header">Changed scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted change notes</h3>
+<h3 class="ui header">Deleted change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted comments</h3>
+<h3 class="ui header">Deleted comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted definitions</h3>
+<h3 class="ui header">Deleted definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted descriptions</h3>
+<h3 class="ui header">Deleted description</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted editorial notes</h3>
+<h3 class="ui header">Deleted editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted examples</h3>
+<h3 class="ui header">Deleted example</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted history notes</h3>
+<h3 class="ui header">Deleted history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted notes</h3>
+<h3 class="ui header">Deleted note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/deleted_property_object_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted scope notes</h3>
+<h3 class="ui header">Deleted scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved change notes</h3>
+<h3 class="ui header">Moved change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved comments</h3>
+<h3 class="ui header">Moved comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved definitions</h3>
+<h3 class="ui header">Moved definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved descriptions</h3>
+<h3 class="ui header">Moved description</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved editorial notes</h3>
+<h3 class="ui header">Moved editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved examples</h3>
+<h3 class="ui header">Moved example</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved history notes</h3>
+<h3 class="ui header">Moved history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved notes</h3>
+<h3 class="ui header">Moved note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/moved_property_object_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved scope notes</h3>
+<h3 class="ui header">Moved scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_change_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_change_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated change notes</h3>
+<h3 class="ui header">Updated change note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:changeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated comments</h3>
+<h3 class="ui header">Updated comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_definition.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_definition.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated definitions</h3>
+<h3 class="ui header">Updated definition</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:definition</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated descriptions</h3>
+<h3 class="ui header">Updated description</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_editorial_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_editorial_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated editorial notes</h3>
+<h3 class="ui header">Updated editorial note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:editorialNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_example.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_example.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated examples</h3>
+<h3 class="ui header">Updated example</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:example</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_history_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_history_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated history notes</h3>
+<h3 class="ui header">Updated history note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:historyNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated notes</h3>
+<h3 class="ui header">Updated note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:note</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_scope_note.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/notes/updated_property_object_property_scope_note.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated scope notes</h3>
+<h3 class="ui header">Updated scope note</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>skos:scopeNote</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added domains</h3>
+<h3 class="ui header">Added domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added is defined bys</h3>
+<h3 class="ui header">Added is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added ranges</h3>
+<h3 class="ui header">Added range</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/added_property_object_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added sub property ofs</h3>
+<h3 class="ui header">Added sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed domains</h3>
+<h3 class="ui header">Changed domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed is defined bys</h3>
+<h3 class="ui header">Changed is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed ranges</h3>
+<h3 class="ui header">Changed range</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/changed_property_object_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed sub property ofs</h3>
+<h3 class="ui header">Changed sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted domains</h3>
+<h3 class="ui header">Deleted domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted is defined bys</h3>
+<h3 class="ui header">Deleted is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted ranges</h3>
+<h3 class="ui header">Deleted range</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/deleted_property_object_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted sub property ofs</h3>
+<h3 class="ui header">Deleted sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved domains</h3>
+<h3 class="ui header">Moved domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved is defined bys</h3>
+<h3 class="ui header">Moved is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved ranges</h3>
+<h3 class="ui header">Moved range</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/moved_property_object_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved sub property ofs</h3>
+<h3 class="ui header">Moved sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_domain.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_domain.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated domains</h3>
+<h3 class="ui header">Updated domain</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:domain</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_is_defined_by.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_is_defined_by.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated is defined bys</h3>
+<h3 class="ui header">Updated is defined by</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:isDefinedBy</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_range.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_range.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated ranges</h3>
+<h3 class="ui header">Updated range</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:range</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_sub_property_of.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/objectproperty/semantic_properties/updated_property_object_property_sub_property_of.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated sub property ofs</h3>
+<h3 class="ui header">Updated sub property of</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:subPropertyOf</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_created.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_created.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added createds</h3>
+<h3 class="ui header">Added created</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:created</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_incompatible_with.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_incompatible_with.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added incompatible withs</h3>
+<h3 class="ui header">Added incompatible with</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>owl:incompatibleWith</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_issued.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_issued.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added issueds</h3>
+<h3 class="ui header">Added issued</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:issued</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_prior_version.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_prior_version.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added prior versions</h3>
+<h3 class="ui header">Added prior version</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>owl:priorVersion</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_version_info.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_version_info.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added version infos</h3>
+<h3 class="ui header">Added version info</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>owl:versionInfo</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_version_iri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/added_property_ontology_version_iri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added version i r is</h3>
+<h3 class="ui header">Added version i r i</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>owl:versionIRI</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_created.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_created.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed createds</h3>
+<h3 class="ui header">Changed created</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:created</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_incompatible_with.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_incompatible_with.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed incompatible withs</h3>
+<h3 class="ui header">Changed incompatible with</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>owl:incompatibleWith</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_issued.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_issued.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed issueds</h3>
+<h3 class="ui header">Changed issued</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:issued</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_prior_version.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_prior_version.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed prior versions</h3>
+<h3 class="ui header">Changed prior version</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>owl:priorVersion</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_version_info.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_version_info.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed version infos</h3>
+<h3 class="ui header">Changed version info</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>owl:versionInfo</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_version_iri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/changed_property_ontology_version_iri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed version i r is</h3>
+<h3 class="ui header">Changed version i r i</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>owl:versionIRI</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_created.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_created.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted createds</h3>
+<h3 class="ui header">Deleted created</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:created</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_incompatible_with.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_incompatible_with.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted incompatible withs</h3>
+<h3 class="ui header">Deleted incompatible with</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>owl:incompatibleWith</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_issued.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_issued.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted issueds</h3>
+<h3 class="ui header">Deleted issued</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:issued</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_prior_version.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_prior_version.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted prior versions</h3>
+<h3 class="ui header">Deleted prior version</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>owl:priorVersion</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_version_info.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_version_info.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted version infos</h3>
+<h3 class="ui header">Deleted version info</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>owl:versionInfo</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_version_iri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/deleted_property_ontology_version_iri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted version i r is</h3>
+<h3 class="ui header">Deleted version i r i</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>owl:versionIRI</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_created.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_created.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved createds</h3>
+<h3 class="ui header">Moved created</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:created</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_incompatible_with.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_incompatible_with.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved incompatible withs</h3>
+<h3 class="ui header">Moved incompatible with</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>owl:incompatibleWith</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_issued.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_issued.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved issueds</h3>
+<h3 class="ui header">Moved issued</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:issued</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_prior_version.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_prior_version.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved prior versions</h3>
+<h3 class="ui header">Moved prior version</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>owl:priorVersion</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_version_info.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_version_info.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved version infos</h3>
+<h3 class="ui header">Moved version info</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>owl:versionInfo</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_version_iri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/moved_property_ontology_version_iri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved version i r is</h3>
+<h3 class="ui header">Moved version i r i</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>owl:versionIRI</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_created.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_created.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated createds</h3>
+<h3 class="ui header">Updated created</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:created</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_incompatible_with.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_incompatible_with.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated incompatible withs</h3>
+<h3 class="ui header">Updated incompatible with</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>owl:incompatibleWith</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_issued.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_issued.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated issueds</h3>
+<h3 class="ui header">Updated issued</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:issued</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_prior_version.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_prior_version.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated prior versions</h3>
+<h3 class="ui header">Updated prior version</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>owl:priorVersion</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_version_info.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_version_info.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated version infos</h3>
+<h3 class="ui header">Updated version info</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>owl:versionInfo</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_version_iri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/evolution_properties/updated_property_ontology_version_iri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated version i r is</h3>
+<h3 class="ui header">Updated version i r i</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>owl:versionIRI</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/added_property_ontology_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/added_property_ontology_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added labels</h3>
+<h3 class="ui header">Added label</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/added_property_ontology_title.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/added_property_ontology_title.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added titles</h3>
+<h3 class="ui header">Added title</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:title</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/changed_property_ontology_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/changed_property_ontology_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed labels</h3>
+<h3 class="ui header">Changed label</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/changed_property_ontology_title.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/changed_property_ontology_title.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed titles</h3>
+<h3 class="ui header">Changed title</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:title</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/deleted_property_ontology_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/deleted_property_ontology_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted labels</h3>
+<h3 class="ui header">Deleted label</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/deleted_property_ontology_title.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/deleted_property_ontology_title.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted titles</h3>
+<h3 class="ui header">Deleted title</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:title</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/moved_property_ontology_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/moved_property_ontology_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved labels</h3>
+<h3 class="ui header">Moved label</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/moved_property_ontology_title.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/moved_property_ontology_title.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved titles</h3>
+<h3 class="ui header">Moved title</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:title</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/updated_property_ontology_label.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/updated_property_ontology_label.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated labels</h3>
+<h3 class="ui header">Updated label</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:label</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/updated_property_ontology_title.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/labels/updated_property_ontology_title.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated titles</h3>
+<h3 class="ui header">Updated title</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:title</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_imports.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_imports.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added importss</h3>
+<h3 class="ui header">Added imports</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>owl:imports</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_license.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_license.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added licenses</h3>
+<h3 class="ui header">Added license</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:license</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_preferred_namespace_prefix.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_preferred_namespace_prefix.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added preferred namespace prefixs</h3>
+<h3 class="ui header">Added preferred namespace prefix</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>vann:preferredNamespacePrefix</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_preferred_namespace_uri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_preferred_namespace_uri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added preferred namespace uris</h3>
+<h3 class="ui header">Added preferred namespace uri</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>vann:preferredNamespaceUri</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_publisher.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_publisher.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added publishers</h3>
+<h3 class="ui header">Added publisher</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:publisher</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_see_also.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/added_property_ontology_see_also.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added see alsos</h3>
+<h3 class="ui header">Added see also</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:seeAlso</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_imports.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_imports.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed importss</h3>
+<h3 class="ui header">Changed imports</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>owl:imports</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_license.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_license.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed licenses</h3>
+<h3 class="ui header">Changed license</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:license</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_preferred_namespace_prefix.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_preferred_namespace_prefix.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed preferred namespace prefixs</h3>
+<h3 class="ui header">Changed preferred namespace prefix</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>vann:preferredNamespacePrefix</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_preferred_namespace_uri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_preferred_namespace_uri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed preferred namespace uris</h3>
+<h3 class="ui header">Changed preferred namespace uri</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>vann:preferredNamespaceUri</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_publisher.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_publisher.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed publishers</h3>
+<h3 class="ui header">Changed publisher</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:publisher</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_see_also.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/changed_property_ontology_see_also.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed see alsos</h3>
+<h3 class="ui header">Changed see also</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:seeAlso</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_imports.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_imports.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted importss</h3>
+<h3 class="ui header">Deleted imports</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>owl:imports</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_license.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_license.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted licenses</h3>
+<h3 class="ui header">Deleted license</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:license</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_preferred_namespace_prefix.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_preferred_namespace_prefix.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted preferred namespace prefixs</h3>
+<h3 class="ui header">Deleted preferred namespace prefix</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>vann:preferredNamespacePrefix</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_preferred_namespace_uri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_preferred_namespace_uri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted preferred namespace uris</h3>
+<h3 class="ui header">Deleted preferred namespace uri</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>vann:preferredNamespaceUri</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_publisher.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_publisher.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted publishers</h3>
+<h3 class="ui header">Deleted publisher</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:publisher</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_see_also.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/deleted_property_ontology_see_also.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted see alsos</h3>
+<h3 class="ui header">Deleted see also</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:seeAlso</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_imports.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_imports.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved importss</h3>
+<h3 class="ui header">Moved imports</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>owl:imports</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_license.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_license.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved licenses</h3>
+<h3 class="ui header">Moved license</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:license</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_preferred_namespace_prefix.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_preferred_namespace_prefix.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved preferred namespace prefixs</h3>
+<h3 class="ui header">Moved preferred namespace prefix</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>vann:preferredNamespacePrefix</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_preferred_namespace_uri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_preferred_namespace_uri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved preferred namespace uris</h3>
+<h3 class="ui header">Moved preferred namespace uri</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>vann:preferredNamespaceUri</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_publisher.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_publisher.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved publishers</h3>
+<h3 class="ui header">Moved publisher</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:publisher</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_see_also.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/moved_property_ontology_see_also.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved see alsos</h3>
+<h3 class="ui header">Moved see also</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:seeAlso</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_imports.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_imports.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated importss</h3>
+<h3 class="ui header">Updated imports</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>owl:imports</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_license.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_license.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated licenses</h3>
+<h3 class="ui header">Updated license</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:license</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_preferred_namespace_prefix.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_preferred_namespace_prefix.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated preferred namespace prefixs</h3>
+<h3 class="ui header">Updated preferred namespace prefix</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>vann:preferredNamespacePrefix</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_preferred_namespace_uri.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_preferred_namespace_uri.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated preferred namespace uris</h3>
+<h3 class="ui header">Updated preferred namespace uri</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>vann:preferredNamespaceUri</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_publisher.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_publisher.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated publishers</h3>
+<h3 class="ui header">Updated publisher</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:publisher</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_see_also.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/miscellaneous/updated_property_ontology_see_also.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated see alsos</h3>
+<h3 class="ui header">Updated see also</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:seeAlso</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/added_property_ontology_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/added_property_ontology_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added comments</h3>
+<h3 class="ui header">Added comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/added_property_ontology_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/added_property_ontology_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Added descriptions</h3>
+<h3 class="ui header">Added description</h3>
 <section class="ui basic segment">
     <p>The table below lists the added <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/changed_property_ontology_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/changed_property_ontology_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed comments</h3>
+<h3 class="ui header">Changed comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/changed_property_ontology_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/changed_property_ontology_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Changed descriptions</h3>
+<h3 class="ui header">Changed description</h3>
 <section class="ui basic segment">
     <p>The table below lists the changed <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/deleted_property_ontology_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/deleted_property_ontology_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted comments</h3>
+<h3 class="ui header">Deleted comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/deleted_property_ontology_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/deleted_property_ontology_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Deleted descriptions</h3>
+<h3 class="ui header">Deleted description</h3>
 <section class="ui basic segment">
     <p>The table below lists the deleted <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/moved_property_ontology_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/moved_property_ontology_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved comments</h3>
+<h3 class="ui header">Moved comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/moved_property_ontology_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/moved_property_ontology_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Moved descriptions</h3>
+<h3 class="ui header">Moved description</h3>
 <section class="ui basic segment">
     <p>The table below lists the moved <strong>dct:description</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/updated_property_ontology_comment.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/updated_property_ontology_comment.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated comments</h3>
+<h3 class="ui header">Updated comment</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>rdfs:comment</strong>
     </p>

--- a/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/updated_property_ontology_description.html
+++ b/resources/templates/owl-core-en-only/template_variants/html/templates/ontology/notes/updated_property_ontology_description.html
@@ -7,7 +7,7 @@
     {% call mc.render_fetch_results(content, error) %}
     {% set compress_uris = simplify_uri_columns_in_tabular(data_frame=content,namespace_inventory=namespaces,error_fail=False) %}
     
-<h3 class="ui header">Updated descriptions</h3>
+<h3 class="ui header">Updated description</h3>
 <section class="ui basic segment">
     <p>The table below lists the updated <strong>dct:description</strong>
     </p>


### PR DESCRIPTION
There is no need to add an `s` and make things more confusing, as that's now how pluralization works for all English words. As per meaningfy-ws/diff-query-generator#31.