### PR TITLE
Fix freezing queries in some cases due to unbound variables

### DIFF
--- a/resources/templates/owl-core-en-only/queries/moved_property_class_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_alt_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_change_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_comment.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_definition.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_description.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_description.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_editorial_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_example.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_example.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_hidden_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_history_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_is_defined_by.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_pref_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_scope_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_class_sub_class_of.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_class_sub_class_of.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_alt_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_change_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_comment.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_definition.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_description.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_domain.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_editorial_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_example.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_hidden_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_history_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_is_defined_by.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_pref_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_range.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_scope_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_datatype_property_sub_property_of.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_alt_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_change_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_comment.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_definition.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_description.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_domain.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_editorial_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_example.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_hidden_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_history_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_is_defined_by.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_pref_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_range.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_scope_note.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_object_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_object_property_sub_property_of.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_comment.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_created.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_created.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_description.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_description.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_imports.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_imports.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_incompatible_with.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_incompatible_with.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_issued.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_issued.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_label.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_license.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_license.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_preferred_namespace_prefix.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_preferred_namespace_prefix.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_preferred_namespace_uri.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_preferred_namespace_uri.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_prior_version.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_prior_version.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_publisher.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_publisher.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_see_also.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_see_also.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_title.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_title.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_version_info.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_version_info.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/owl-core-en-only/queries/moved_property_ontology_version_iri.rq
+++ b/resources/templates/owl-core-en-only/queries/moved_property_ontology_version_iri.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_comment.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_comment.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_is_defined_by.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_is_defined_by.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_label.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_property.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_property.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_target_class.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_node_shape_target_class.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_comment.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_comment.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_created.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_created.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_description.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_description.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_imports.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_imports.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_incompatible_with.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_incompatible_with.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_issued.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_issued.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_label.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_label.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_license.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_license.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_preferred_namespace_prefix.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_preferred_namespace_prefix.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_preferred_namespace_uri.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_preferred_namespace_uri.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_prior_version.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_prior_version.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_publisher.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_publisher.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_see_also.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_see_also.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_title.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_title.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_version_info.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_version_info.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_ontology_version_iri.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_ontology_version_iri.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_class.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_class.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_datatype.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_datatype.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_description.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_description.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_is_defined_by.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_is_defined_by.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_language_in.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_language_in.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_count.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_count.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_exclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_exclusive.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_inclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_inclusive.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_length.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_max_length.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_count.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_count.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_exclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_exclusive.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_inclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_inclusive.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_length.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_min_length.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_name.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_name.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_path.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_path.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_pattern.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_pattern.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_unique_lang.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_property_property_shape_unique_lang.rq
@@ -69,17 +69,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -100,17 +100,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 

--- a/resources/templates/shacl-core-en-only/queries/moved_reified_property_shape_sparql_select.rq
+++ b/resources/templates/shacl-core-en-only/queries/moved_reified_property_shape_sparql_select.rq
@@ -80,17 +80,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?newInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?newInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?newInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 
@@ -112,17 +112,17 @@ WHERE {
     
     # fall back to known labels if no preview property
     optional {
-      ?instance rdfs:label ?rdfsLabelEn .
+      ?oldInstance rdfs:label ?rdfsLabelEn .
       FILTER(LANG(?rdfsLabelEn) = "" || LANGMATCHES(LANG(?rdfsLabelEn), "en"))
     }
 
     optional {
-      ?instance skos:prefLabel ?skosLabelEn .
+      ?oldInstance skos:prefLabel ?skosLabelEn .
       FILTER(LANG(?skosLabelEn) = "" || LANGMATCHES(LANG(?skosLabelEn), "en"))
     }
 
     optional {
-      ?instance shacl:name ?shaclNameEn .
+      ?oldInstance shacl:name ?shaclNameEn .
       FILTER(LANG(?shaclNameEn) = "" || LANGMATCHES(LANG(?shaclNameEn), "en"))
     }
 


### PR DESCRIPTION
The cross-instance movement delta queries do not finish for certain diffs (of a certain size), like ePO SHACL 4.x and 5.x. This is because in commit e9d32e7863efc9ee02d54c264c1eac3ff46e81d4 "Update new profiles to use fallback label properties" a blanket update was made for the alternative label fallback OPTIONAL queries, which missed that in some cases there were subqueries bound to `?newInstance` and `?oldInstance` but `?instance` was used. This led to a cardinality explosion.

Fixed as per as per meaningfy-ws/diff-query-generator#32.