### PR TITLE
Initial support for fetching embedded SHACL info in OWL

### DIFF
--- a/resources/templates/owl-core-en-only/queries/added_instance_class.rq
+++ b/resources/templates/owl-core-en-only/queries/added_instance_class.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/added_instance_datatype_property.rq
+++ b/resources/templates/owl-core-en-only/queries/added_instance_datatype_property.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
-SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
+SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ?domain ?range ?minCardinality ?maxCardinality ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,18 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
+  # and we get some domain, range and cardinality information from SHACL shapes if available
+  OPTIONAL {
+    GRAPH ?newVersionGraph {
+        ?nodeShape shacl:property ?propertyShape ;
+                   shacl:targetClass ?domain .
+        ?propertyShape shacl:path ?instance ;
+                       shacl:datatype ?range .
+      OPTIONAL { ?propertyShape shacl:minCount ?minCardinality }
+      OPTIONAL { ?propertyShape shacl:maxCount ?maxCardinality }
+    }
+  }
+
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/added_instance_object_property.rq
+++ b/resources/templates/owl-core-en-only/queries/added_instance_object_property.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
-SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
+SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ?domain ?range ?minCardinality ?maxCardinality ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,27 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
+  # and we get some domain, range and cardinality information from SHACL shapes if available
+  OPTIONAL {
+    GRAPH ?newVersionGraph {
+      {  
+        ?nodeShape shacl:property ?propertyShape ;
+                   shacl:targetClass ?domain .
+        ?propertyShape shacl:path ?instance ;
+                       shacl:class ?range .
+      }
+      UNION
+      {
+        ?nodeShape shacl:property ?propertyShape ;
+                   shacl:targetClass ?domain .
+        ?propertyShape shacl:path ?instance ;
+                       shacl:node/shacl:property/shacl:hasValue ?range .
+      }
+      OPTIONAL { ?propertyShape shacl:minCount ?minCardinality }
+      OPTIONAL { ?propertyShape shacl:maxCount ?maxCardinality }
+    }
+  }
+
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/added_instance_ontology.rq
+++ b/resources/templates/owl-core-en-only/queries/added_instance_ontology.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/added_instance_node_shape.rq
+++ b/resources/templates/shacl-core-en-only/queries/added_instance_node_shape.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/added_instance_ontology.rq
+++ b/resources/templates/shacl-core-en-only/queries/added_instance_ontology.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/added_instance_property_shape.rq
+++ b/resources/templates/shacl-core-en-only/queries/added_instance_property_shape.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -101,5 +103,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/added_instance_concept.rq
+++ b/resources/templates/skos-core-en-only/queries/added_instance_concept.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -88,5 +90,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/added_instance_concept_scheme.rq
+++ b/resources/templates/skos-core-en-only/queries/added_instance_concept_scheme.rq
@@ -36,7 +36,9 @@ PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
 PREFIX sh: <http://purl.org/skos-history/>
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 # identify added instances
+
 SELECT distinct ?class ?instance ?prefLabel ?prefLabelLang ("addition" as ?actionType)
+
 WHERE {
   GRAPH ?versionHistoryGraph {
     # parameters
@@ -88,5 +90,6 @@ WHERE {
       ?instance ?p [] .
     }
   }
+
 }
 ORDER BY ?instance


### PR DESCRIPTION
Support fetching domain, range and cardinality information from vocabularies containing a SHACL graph. The queries are different depending on whether it is an object property or a datatype property. Where the information isn't available, there will be empty cells in the report.

There is also support for value node constraints for certain patterns of expressing ranges for IRIs with `sh:hasValue`, such as SKOS vocabularies, used for example in recent versions of the eProcurement ontology (ePO):

```ttl
sh:nodeKind sh:IRI ;
sh:node [
  rdf:type sh:NodeShape ;
  sh:property [
    sh:path skos:inScheme ;
    sh:hasValue atold:language ;
  ] ;
] .
```

Currently, this feature is NOT for capturing changes in the domain, range and cardinality, and is only for the case of ADDED instances of such resources, not their modifications.

The information won't show up for individual property changes on the resources (added/updated/changed/moved labels and the whole shebang). The queries in those cases will differ between modification types, and there is the question of how to fit all of the information in an already-crowded table. Work will continue on how best to approach this.

P.S: There are nested OPTIONALs as the graph may not exist, so performance may be affected, though hopefully not by too much. If that becomes a concern, we can turn these over onto a new template, where a SHACL graph would be made mandatory.

Application of meaningfy-ws/diff-query-generator#34.

**Note:** In order to test this, one needs to concatenate the OWL and SHACL artefacts, merge the prefixes and remove the SHACL Ontology header, for both old and new versions, and load those combined artefacts. A script will be provided for this at a later time, but for now, you may use the following attached files (rename the extension from `.txt` to `.ttl`).

**Synthetic Example**
- old: [ePO_sample-4.0.0.orig.txt](https://github.com/user-attachments/files/23496360/ePO_sample-4.0.0.orig.txt)
- new: [ePO_sample-4.0.0.upd.txt](https://github.com/user-attachments/files/23496361/ePO_sample-4.0.0.upd.txt)

(lightweight files, faster to diff, only 1 shape)

**Real Example**
- old: [ePO_core_combined-4.1.0.txt](https://github.com/user-attachments/files/23496298/ePO_core_combined-4.1.0.txt)
- new: [ePO_core_combined-4.2.0.txt](https://github.com/user-attachments/files/23496300/ePO_core_combined-4.2.0.txt)

(up to several minutes for diffing depending on hardware)

<img width="2102" height="551" alt="image" src="https://github.com/user-attachments/assets/bb331861-9c78-4061-a98b-72efa10e591a" />

See also profiling results in [comment](https://github.com/meaningfy-ws/rdf-differ-ws/pull/138#issuecomment-3523546341).