### PR TITLE
fix(infra): install curl in the worker image so the diff pipeline runs (status 127)

### DIFF
--- a/infra/api/Dockerfile
+++ b/infra/api/Dockerfile
@@ -11,6 +11,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /usr/src/app
 
+# curl is required by resources/load_versions.sh (the diff-loading shell pipeline the
+# Celery worker invokes); the slim base image does not ship it.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install "poetry==${POETRY_VERSION}"
 
 # Install runtime deps first so this layer caches until the lockfile changes.


### PR DESCRIPTION
The Celery worker invokes resources/load_versions.sh, which calls curl for every SPARQL PUT/UPDATE. The slim base image lacks curl, so version loading failed with status 127 and no diff was computed. This installs curl in the api/worker image.

Verified end-to-end on the live Docker stack: create-diff → Celery task **succeeds** → the dataset is listed in /diffs with its versions and query URL.