### PR TITLE
Resilience: fail fast on Redis/Celery outage + stronger diff-semantics verification

### DIFF
--- a/infra/scripts/rdf-differ.sh
+++ b/infra/scripts/rdf-differ.sh
@@ -35,9 +35,37 @@ wait_for_task() {
     local task_id=$1
     local description=$2
     local print_mode=$3
+    # #133: bounded, reachability-aware polling so a down API/Redis no longer
+    # freezes the command forever.
+    local max_attempts=${RDF_DIFFER_TASK_MAX_ATTEMPTS:-120}  # ~10 min at 5s
+    local max_lost_contact=3                                 # consecutive failed polls before aborting
+    local attempts=0
+    local lost_contact=0
     [[ "$print_mode" == "print" ]] && echo "⏳ Waiting for ${description} task (${task_id}) to complete..."
     while true; do
-        local STATUS=$(curl -s -L -k "${BASE_URL}/tasks/${task_id}" -H 'accept: application/json' | jq -r '.status')
+        attempts=$((attempts + 1))
+        if (( attempts > max_attempts )); then
+            echo "❌ Timed out waiting for ${description} task (${task_id}) after ${max_attempts} polls"
+            exit 1
+        fi
+        # -fsS fails (non-zero) on transport errors and HTTP >= 400 (e.g. a 503
+        # from a down result backend), so an unreachable API surfaces here.
+        local RESPONSE
+        if ! RESPONSE=$(curl -fsS -L -k "${BASE_URL}/tasks/${task_id}" -H 'accept: application/json'); then
+            RESPONSE=""
+        fi
+        local STATUS
+        STATUS=$(echo "${RESPONSE}" | jq -r '.status' 2>/dev/null)
+        if [[ -z "${STATUS}" || "${STATUS}" == "null" ]]; then
+            lost_contact=$((lost_contact + 1))
+            if (( lost_contact >= max_lost_contact )); then
+                echo "❌ Lost contact with the API while waiting for ${description} task (${task_id})"
+                exit 1
+            fi
+            sleep 5
+            continue
+        fi
+        lost_contact=0
         [[ "$print_mode" == "print" ]] && echo "   Task status: ${STATUS}"
         if [[ "${STATUS}" == "SUCCESS" ]]; then
             [[ "$print_mode" == "print" ]] && echo "✅ Task completed successfully"

--- a/rdf_differ/api/entrypoints/api/routes.py
+++ b/rdf_differ/api/entrypoints/api/routes.py
@@ -11,6 +11,7 @@ from json import dumps
 from pathlib import Path
 from typing import cast
 
+import redis
 import requests
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi import Path as PathParam
@@ -296,14 +297,26 @@ def list_active_tasks() -> list:
 def get_task_status(task_id: str = PathParam(...)) -> dict:
     """Get the status of a task."""
     logger.debug(f"get task status: {task_id}")
-    task = retrieve_task(task_id)
-    if not task:
-        raise HTTPException(HTTPStatus.NOT_FOUND, f"Task with {task_id} doesn't exist")
+    # Reading task state hits the Celery result backend (Redis). If it is
+    # unreachable the underlying client raises a connection error; surface a
+    # clear 503 rather than letting it escape as an unhandled 500 or hang
+    # (#133 hardening). The redis socket timeouts bound the wait.
     try:
-        result = dumps(task.result)
-    except TypeError:
-        result = ""
-    return {"task_id": task.id, "status": task.status, "result": result}
+        task = retrieve_task(task_id)
+        if not task:
+            raise HTTPException(HTTPStatus.NOT_FOUND, f"Task with {task_id} doesn't exist")
+        status = task.status
+        try:
+            result = dumps(task.result)
+        except TypeError:
+            result = ""
+        return {"task_id": task.id, "status": status, "result": result}
+    except HTTPException:
+        raise
+    except (redis.exceptions.RedisError, ConnectionError, OSError) as exception:
+        text = "task status backend unavailable"
+        logger.exception(text)
+        raise HTTPException(HTTPStatus.SERVICE_UNAVAILABLE, text) from exception
 
 
 @router.delete("/tasks/{task_id}")

--- a/rdf_differ/core/adapters/redis.py
+++ b/rdf_differ/core/adapters/redis.py
@@ -4,9 +4,16 @@ import redis
 
 from rdf_differ import config
 
+# Fail-fast socket timeouts (seconds): a down Redis must not hang the
+# CLI/API on connect or read (#133 hardening). A small constant is enough;
+# we deliberately avoid inventing new config plumbing.
+REDIS_SOCKET_TIMEOUT = 5
+
 redis_client = redis.Redis(
     host=config.RDF_DIFFER_REDIS_LOCATION.split("redis://")[1],
     port=int(config.RDF_DIFFER_REDIS_PORT),
+    socket_connect_timeout=REDIS_SOCKET_TIMEOUT,
+    socket_timeout=REDIS_SOCKET_TIMEOUT,
 )
 
 REVOKING_QUEUE = "revoke"

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -299,6 +299,19 @@ def test_get_task_status_404(mock_retrieve):
     assert resp.status_code == 404
 
 
+@patch(f"{ROUTES}.retrieve_task")
+def test_get_task_status_503_when_backend_down(mock_retrieve):
+    """A down Redis result backend returns 503, not an unhandled 500/hang (#133)."""
+    import redis
+
+    mock_retrieve.side_effect = redis.exceptions.ConnectionError("backend down")
+
+    resp = client.get("/tasks/t1")
+
+    assert resp.status_code == 503
+    assert "backend unavailable" in resp.json()["detail"]
+
+
 @patch(f"{ROUTES}.kill_task")
 @patch(f"{ROUTES}.flatten_active_tasks", return_value=[{"id": "t1"}])
 @patch(f"{ROUTES}.retrieve_active_tasks", return_value={})

--- a/tests/unit/test_diff_semantics_fuseki_integration.py
+++ b/tests/unit/test_diff_semantics_fuseki_integration.py
@@ -1,0 +1,164 @@
+"""Live-Fuseki verification of the diff-semantics filter relaxation (#142, #143).
+
+EPIC: resolve-open-issues — Capability 3 (diff-semantics).
+
+The sibling ``test_diff_semantics_queries.py`` executes the committed
+``updated_property_*.rq`` templates against an in-memory ``rdflib.Dataset``. rdflib is a
+fine SPARQL engine, but the templates run in production against *Fuseki* (Apache Jena).
+This test closes that gap: it loads the SAME minimal skos-history fixture into a real
+Fuseki dataset over SPARQL Update, runs the real lang-fallback ``updated_property``
+query through ``FusekiDiffAdapter.execute_query``, and asserts the #142/#143 rows surface
+on the real engine.
+
+Marked ``@pytest.mark.integration`` (the repo auto-deselects integration tests by
+default; ``make``/CI run them with services up). When no Fuseki is reachable the test
+skips gracefully so a plain ``pytest`` run never errors.
+"""
+
+import contextlib
+import uuid
+
+import pytest
+import rdflib
+import requests
+
+from rdf_differ import config
+from rdf_differ.core.adapters.sparql import SPARQLRunner
+from rdf_differ.diffing.adapters.diff_adapter import FusekiDiffAdapter
+
+# Reuse the exact fixture vocabulary + builder helpers from the in-memory test so the
+# two executions verify identical data. (We may only touch these two files, and
+# importing the unit-test module is the clean way to share the fixture.)
+from tests.unit.test_diff_semantics_queries import (
+    CONCEPT,
+    CONCEPT_CLASS,
+    DEL_GRAPH,
+    INS_GRAPH,
+    LANG_FALLBACK_QUERY,
+    NEW_GRAPH,
+    OLD_GRAPH,
+    PREF_LABEL,
+    VHG,
+    _metadata_turtle,
+)
+
+# A fixed, stable dataset name (no Math.random/Date) — cleaned up in a finally block.
+# A run-unique suffix keeps parallel/concurrent runs from clobbering each other.
+DATASET_NAME = f"diff_semantics_it_{uuid.uuid4().hex[:8]}"
+
+PING_TIMEOUT_SECONDS = 2
+
+L = rdflib.Literal
+URI = rdflib.URIRef
+
+
+def _fuseki_is_up() -> bool:
+    """Probe Fuseki's ping endpoint; any connection problem means 'not up'."""
+    ping_url = f"{config.RDF_DIFFER_FUSEKI_SERVICE}/$/ping"
+    try:
+        response = requests.get(ping_url, timeout=PING_TIMEOUT_SECONDS)
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def _insert_data_update(graph_iri: str, triples: str) -> str:
+    """Wrap N-Triples-ish body in an INSERT DATA targeting a named graph."""
+    return f"INSERT DATA {{ GRAPH <{graph_iri}> {{ {triples} }} }}"
+
+
+def _term(node) -> str:
+    """Serialise an rdflib term to SPARQL syntax (literal with tag / IRI)."""
+    return node.n3()
+
+
+def _load_fixture(adapter: FusekiDiffAdapter, old_value, new_value) -> None:
+    """Emit the same skos-history layout as the in-memory test as SPARQL Updates.
+
+    One INSERT DATA per named graph: version-history metadata, old version, new
+    version, deletions, insertions.
+    """
+    concept = f"<{CONCEPT}>"
+    pref = f"<{PREF_LABEL}>"
+    cls = f"<{CONCEPT_CLASS}>"
+    old_n3 = _term(old_value)
+    new_n3 = _term(new_value)
+
+    # version-history metadata graph (turtle -> n-triples for INSERT DATA body)
+    metadata_graph = rdflib.Graph()
+    metadata_graph.parse(data=_metadata_turtle(), format="turtle")
+    metadata_triples = metadata_graph.serialize(format="nt")
+
+    updates = [
+        _insert_data_update(VHG, metadata_triples),
+        _insert_data_update(OLD_GRAPH, f"{concept} a {cls} . {concept} {pref} {old_n3} ."),
+        _insert_data_update(NEW_GRAPH, f"{concept} a {cls} . {concept} {pref} {new_n3} ."),
+        _insert_data_update(DEL_GRAPH, f"{concept} {pref} {old_n3} ."),
+        _insert_data_update(INS_GRAPH, f"{concept} {pref} {new_n3} ."),
+    ]
+    for update in updates:
+        adapter.execute_update_query(dataset_name=DATASET_NAME, sparql_query=update)
+
+
+def _run_query(adapter: FusekiDiffAdapter) -> list[dict]:
+    """Run the real lang-fallback query and return SPARQL JSON bindings."""
+    result = adapter.execute_query(
+        dataset_name=DATASET_NAME, sparql_query=LANG_FALLBACK_QUERY.read_text()
+    )
+    return result["results"]["bindings"]
+
+
+def _values(bindings: list[dict], var: str) -> set[str]:
+    return {row[var]["value"] for row in bindings if var in row}
+
+
+@pytest.mark.integration
+def test_relaxed_filter_surfaces_updates_on_real_fuseki():
+    """The #142/#143 cases surface as ``updated`` rows on a real Fuseki engine."""
+    if not _fuseki_is_up():
+        pytest.skip(
+            f"Fuseki not reachable at {config.RDF_DIFFER_FUSEKI_SERVICE}; "
+            "skipping live integration test."
+        )
+
+    adapter = FusekiDiffAdapter(config.RDF_DIFFER_FUSEKI_SERVICE, requests, SPARQLRunner())
+
+    adapter.create_dataset(DATASET_NAME)
+    try:
+        # (a) #142 language-tag change: 'text'@en -> 'text'@fr
+        _load_fixture(adapter, L("text", lang="en"), L("text", lang="fr"))
+        bindings = _run_query(adapter)
+        assert bindings, "language-tag change produced no update row on Fuseki"
+        assert "text" in _values(bindings, "oldValue")
+        assert "text" in _values(bindings, "newValue")
+
+        # reset graphs between cases by recreating the dataset
+        adapter.delete_dataset(DATASET_NAME)
+        adapter.create_dataset(DATASET_NAME)
+
+        # (b) #142 language-tag removal: 'text'@en -> 'text'
+        _load_fixture(adapter, L("text", lang="en"), L("text"))
+        bindings = _run_query(adapter)
+        assert bindings, "language-tag removal produced no update row on Fuseki"
+
+        adapter.delete_dataset(DATASET_NAME)
+        adapter.create_dataset(DATASET_NAME)
+
+        # (c) #143 literal -> IRI: 'label' -> <http://ex/iri>
+        _load_fixture(adapter, L("label"), URI("http://ex/iri"))
+        bindings = _run_query(adapter)
+        assert bindings, "literal->IRI change produced no update row on Fuseki"
+        assert "http://ex/iri" in _values(bindings, "newValue")
+
+        adapter.delete_dataset(DATASET_NAME)
+        adapter.create_dataset(DATASET_NAME)
+
+        # (d) unchanged value must NOT be reported
+        _load_fixture(adapter, L("text", lang="en"), L("text", lang="en"))
+        bindings = _run_query(adapter)
+        assert not bindings, f"unchanged value wrongly reported on Fuseki: {bindings}"
+    finally:
+        # The dataset may already be gone (a case branch deleted it before failing);
+        # cleanup is best-effort and must never mask the real assertion failure.
+        with contextlib.suppress(Exception):
+            adapter.delete_dataset(DATASET_NAME)

--- a/tests/unit/test_diff_semantics_queries.py
+++ b/tests/unit/test_diff_semantics_queries.py
@@ -31,6 +31,13 @@ LANG_FALLBACK_QUERY = (
     TEMPLATES_DIR / "skos-core-lang-fallback" / "queries" / "updated_property_concept_pref_label.rq"
 )
 
+# The "rich" multi-case filter shape (Cases 1-4 spelled out explicitly), used by the
+# en-only / owl-core / shacl-core profiles. Same class+property as the lang-fallback
+# query, so the shared fixture drives both. Picking en-only as the representative.
+EN_ONLY_QUERY = (
+    TEMPLATES_DIR / "skos-core-en-only" / "queries" / "updated_property_concept_pref_label.rq"
+)
+
 # --- namespaces used by the skos-history layout ------------------------------
 
 EX = "http://example.org/"
@@ -129,9 +136,18 @@ def _run(query_text: str, ds: rdflib.Dataset):
     return list(ds.query(query_text))
 
 
-@pytest.fixture(scope="module")
-def query_text() -> str:
-    return LANG_FALLBACK_QUERY.read_text()
+# Both committed filter shapes execute through the SAME assertions: the "simple"
+# lang-fallback filter and the "rich" en-only filter (Cases 1-4 spelled out).
+# Parametrising here proves the relaxation works for both shapes, not just one.
+QUERY_SHAPES = {
+    "simple-lang-fallback": LANG_FALLBACK_QUERY,
+    "rich-en-only": EN_ONLY_QUERY,
+}
+
+
+@pytest.fixture(scope="module", params=sorted(QUERY_SHAPES), ids=sorted(QUERY_SHAPES))
+def query_text(request) -> str:
+    return QUERY_SHAPES[request.param].read_text()
 
 
 # --- the three relaxation cases (#142 / #143) --------------------------------

--- a/tests/unit/test_rdf_differ_sh_contract.py
+++ b/tests/unit/test_rdf_differ_sh_contract.py
@@ -24,6 +24,14 @@ def _create_diff_body(text: str) -> str:
     return text[start:end]
 
 
+def _wait_for_task_body(text: str) -> str:
+    """Return the body of the wait_for_task() bash function."""
+    start = text.index("wait_for_task()")
+    # The next top-level function definition marks the end of wait_for_task().
+    end = text.index("create_diff()", start)
+    return text[start:end]
+
+
 def test_script_exists():
     assert SCRIPT_PATH.is_file(), f"missing script: {SCRIPT_PATH}"
 
@@ -80,3 +88,41 @@ def test_reachability_probe_against_base_url():
         'expected a cheap reachability probe: curl -fsS -m 5 -o /dev/null "${BASE_URL}/diffs"'
     )
     assert "RDF Differ API not reachable at ${BASE_URL}" in text
+
+
+# --- #133 hardening: bounded, reachability-aware wait_for_task --------------
+
+
+def test_wait_for_task_is_not_an_unbounded_busy_loop():
+    """#133: the poller must not be a bare `while true` without a counter/cap."""
+    body = _wait_for_task_body(_read_script())
+    if re.search(r"while\s+true", body):
+        # An unbounded `while true` is only acceptable with an attempt counter
+        # incremented inside the loop that can break/exit it.
+        assert re.search(r"attempts?\b", body), (
+            "wait_for_task uses `while true` but has no attempt counter to bound it"
+        )
+
+
+def test_wait_for_task_has_a_max_attempts_cap():
+    """#133: an overall attempt cap exists (overridable via env) and aborts on timeout."""
+    body = _wait_for_task_body(_read_script())
+    assert re.search(r"max_attempts=\$\{RDF_DIFFER_TASK_MAX_ATTEMPTS:-\d+\}", body), (
+        "wait_for_task must define max_attempts from RDF_DIFFER_TASK_MAX_ATTEMPTS with a default"
+    )
+    # On exceeding the cap it prints a timeout message and exits non-zero.
+    assert re.search(r"(?i)timed?\s*out|timeout", body), (
+        "wait_for_task must print a clear timeout message when the cap is exceeded"
+    )
+    assert "exit 1" in body
+
+
+def test_wait_for_task_aborts_on_lost_contact():
+    """#133: repeated curl/transport failures abort instead of looping forever."""
+    body = _wait_for_task_body(_read_script())
+    # Uses a curl form that fails on transport/HTTP error so 503/unreachable is detectable.
+    assert "curl -fsS" in body, "wait_for_task must use curl -fsS to detect transport/HTTP errors"
+    assert "Lost contact with the API" in body, (
+        "wait_for_task must report lost contact with the API"
+    )
+    assert "exit 1" in body

--- a/tests/unit/test_redis.py
+++ b/tests/unit/test_redis.py
@@ -1,9 +1,19 @@
 from rdf_differ.core.adapters.redis import (
+    REDIS_SOCKET_TIMEOUT,
     push_task_to_queue,
+    redis_client,
     remove_task_from_queue,
     task_exists_in_queue,
 )
 from tests.conftest import FakeRedisClient
+
+
+def test_redis_client_has_failfast_socket_timeouts():
+    """A down Redis must not hang the client on connect/read (#133 hardening)."""
+    kwargs = redis_client.connection_pool.connection_kwargs
+
+    assert kwargs.get("socket_connect_timeout") == REDIS_SOCKET_TIMEOUT
+    assert kwargs.get("socket_timeout") == REDIS_SOCKET_TIMEOUT
 
 
 def test_push_task_to_revoking_queue():


### PR DESCRIPTION
Follow-ups to 2.3.0 (#133 hardening + #142/#143 verification). No new release cut yet — intended to bundle with the upcoming report-download fix.

## Resilience (#133, further) — no more hanging when Redis/Celery is down mid-run
- **Redis client** gets fail-fast `socket_connect_timeout`/`socket_timeout` (was unbounded → hung on a down Redis).
- **`GET /tasks/{id}`** returns **503** (not an unhandled 500 / hang) when the result backend is unreachable.
- **Bash `wait_for_task`** is now **bounded** (max-attempts cap, env-overridable) and **aborts on lost contact** with the API instead of looping forever (the "frozen command").

Blast radius confirmed LOW via GitNexus (each touched symbol has 1–2 direct callers; redis adapter already injectable).

## Diff-semantics verification (#142, #143) — close the 2.3.0 gap
- rdflib execution test now runs **both** filter shapes (simple lang-fallback + rich en-only) for the tag-change / tag-removal / literal→IRI cases.
- New **`@integration`** test loads the skos-history fixture into a **live Fuseki** and runs the real query against Jena's engine; **skips cleanly** when Fuseki is unreachable.

## Verification
`make check-quality` green · `make check-architecture` 10/10 · `make test-unit` 345 passed, 2 deselected (integration).