### PR TITLE
Report delivery UX: serve live, signal completion, keep downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,20 @@ Once ready (the task has disappeared), navigate back to the diff, and a new sect
 
 ![Download reports page](docs/images/download-reports.png)
 
+#### Viewing and downloading reports
+
+After you click **Build report**, the diff page shows a progress banner for the
+profile and template you requested and polls the build in the background. When the
+build finishes the page refreshes automatically and the new report appears under
+**Available reports**; if the build fails, the banner says so instead of spinning
+forever.
+
+Each report variant offers two actions:
+
+- **View** — opens the report in a new browser tab and renders it live. HTML reports
+  display as a page; JSON and AsciiDoc reports are shown inline as text.
+- **Download** — saves the report to disk as a file (the same behaviour as before).
+
 > **Note:** If you see an error for any of the pages, your setup is not right. Please either check your local services, or rebuild the Docker services if you are using that (including deleting the associated volumes). Check also that Celery is running, which is needed for the asynchronous tasks.
 
 ### The Differ API

--- a/openspec/changes/report-delivery-ux/design.md
+++ b/openspec/changes/report-delivery-ux/design.md
@@ -1,0 +1,70 @@
+# PLAN — design (report-delivery-ux)
+
+> EPIC: report-delivery-ux. PLAN ≡ this design + `tasks.md`.
+
+## Current flow (what works, what's missing)
+
+```
+build form ──POST /diffs/{id}──> api_client.build_report ──POST /diffs/report──> API enqueues
+   Celery async_generate_report ──> writes {reports_db}/{name}/{ap}/{type}/<file>   [WORKS]
+GET /diffs/{id} ──> get_diff sets dataset.available_reports = get_all_reports(...)   [WORKS]
+view_dataset template ──> renders Download links per variant                          [WORKS]
+download_report ──> streams file as attachment                                        [WORKS]
+        ^
+        └── MISSING: nothing tells the user the build finished; no live view.
+```
+
+The API returns `{"task_id": ..., "application_profile": ...}` from `POST /diffs/report`, and
+`GET /tasks/{id}` returns `{"task_id","status","result"}`. Both already exist.
+
+## Changes (UI entrypoint only)
+
+### 1. `api_client.py`
+- Add `get_task(task_id) -> ApiResult` → `_request("GET", f"/tasks/{task_id}")`.
+- (Reuse the existing `build_report`, which returns an `ApiResult` whose `.json` carries
+  `task_id`, and `get_report`, which returns the raw bytes response.)
+
+### 2. `ui/routes.py`
+- **`build_report`**: on success read `task_id = result.json.get("task_id")` and redirect to
+  `view_dataset` with query params `?building=<task_id>&ap=<ap>&tt=<tt>` (keep the flash).
+- **`view_dataset`**: accept optional `building`, `ap`, `tt` query params and pass them to the
+  template so it can show the banner + poller.
+- **New `task_status` route** `GET /tasks/{task_id}/status` (name `task_status`): proxy
+  `api_client.get_task(task_id)` → return `JSONResponse({"status": ...})` (404/503 surfaced as
+  a status string the poller can handle). Same-origin so the browser fetch needs no CORS.
+- **New `view_report` route** `GET /diff-report/{dataset_id}/{ap}/{tt}/view` (name
+  `view_report`): call `api_client.get_report(...)`; if 200 return `Response(content=bytes,
+  media_type=<from upstream content-type>, headers={"content-disposition": "inline"})`; else
+  flash + redirect (mirror `download_report`'s error handling). This makes the browser render
+  the HTML live / show JSON/ASCII.
+
+### 3. Templates (`dataset/view_dataset.html`)
+- **Available reports list**: for each `variant`, render **View** (→ `view_report`, `target="_blank"`)
+  and **Download** (→ `download_report`) actions per row.
+- **Building banner**: when `building` is set, show "⏳ Building `{{ap}}` · `{{tt}}` report…" and
+  a `<script>` poller: every 3s `fetch('/tasks/{building}/status')`; on `SUCCESS` →
+  `location.replace(view_dataset url without query)` (report now listed) and surface a
+  "ready" prompt; on `FAILED`/`ERROR` → replace banner with an error; bounded to ~100 polls
+  then show "still building — refresh later". Dependency-free vanilla JS, consistent with the
+  existing template-type dropdown script.
+
+## Verification
+
+- **Unit (UI routes, Flask/Starlette test client)** — see existing `tests/unit/test_ui_routes.py`:
+  - `build_report` success redirects with `building`/`ap`/`tt` query params (task_id threaded).
+  - `view_dataset` with `?building=...` renders the banner + poller markup.
+  - `task_status` returns the upstream status JSON; degrades to a status string on API error.
+  - `view_report` returns the report bytes with an **inline** disposition and the right
+    media type for 200; flashes + redirects when the report is missing.
+  - Report list renders both View and Download links per variant.
+- **BDD** — `tests/features/report_delivery.feature` + steps in `tests/feature/`: build → see
+  building state → on completion the report is listed and can be viewed inline or downloaded;
+  edge (build fails → error shown); negative (view a non-existent report → friendly redirect).
+- Quality gate: `make check-quality`, `make check-architecture`, `make test-unit` green.
+
+## Risks
+
+- **Self-contained HTML** confirmed for current templates (inline style, remote-only refs). If a
+  template later emits local assets, the single-file inline view loses styling → DEC-4 escalation.
+- **Poller** must stop on terminal states and cap total polls so a stuck task doesn't spin forever
+  (mirrors the bash `wait_for_task` bound added for #133).

--- a/openspec/changes/report-delivery-ux/proposal.md
+++ b/openspec/changes/report-delivery-ux/proposal.md
@@ -1,0 +1,68 @@
+# EPIC — Report delivery UX: serve, view and discover built reports
+
+> Shape-Up work shape. EPIC ≡ this proposal. Drives the PLAN (`design.md` + `tasks.md`)
+> and the capability spec under `specs/report-delivery/`.
+
+## Appetite
+
+Small batch — one feature branch. UI-layer change plus a thin api-client method; the REST
+API and report storage already do everything needed. No new infrastructure.
+
+## Why (the bet)
+
+After the 2.2.0 FastAPI rewrite, a user who builds a report has **no way to tell when it is
+ready**: `POST /diffs/{id}` enqueues a Celery task, flashes "Report building started.", and
+redirects — but the page does not reflect progress and the freshly-built report only appears
+after a *manual* refresh. To the user this reads as "the software does not deliver the basic
+functionality." The download route itself works; the **completion signal and a live view are
+missing**.
+
+In 2.1.0 the loop was discoverable (documented build → list → download, with screenshots) so
+reports "were served well". The rewrite preserved the download route but dropped the feedback
+loop. This EPIC restores a trustworthy loop and adds **serving the report live** (the
+explicitly preferred option) alongside download.
+
+## Solution outline
+
+Three affordances on the dataset (diff) view, all UI-layer:
+
+1. **Serve/view live (preferred).** A new `view_report` route serves a built report **inline**
+   so the browser renders it: HTML reports display as a page, JSON/ASCII show in the browser.
+   HTML reports are self-contained (inline `<style>`, only remote/CDN refs), so a single-file
+   inline response renders correctly. Each report variant gets a **View** link (opens in a new
+   tab) next to the existing **Download** link.
+
+2. **Discover when ready (completion signal).** `build_report` captures the `task_id` the API
+   returns and redirects to the dataset view with it. The view shows a "Building `<ap>` ·
+   `<type>`…" banner and a small dependency-free poller that hits a same-origin task-status
+   endpoint; on success it refreshes so the new report appears (and surfaces a "ready —
+   View / Download" prompt); on failure it shows an error. No manual refresh.
+
+3. **List to download (kept, clarified).** The existing per-variant download list stays; each
+   row now offers both View and Download, grouped by application profile and template type.
+
+## Key decisions
+
+- **DEC-1** All changes live in the UI entrypoint (`routes.py`, `api_client.py`, templates) +
+  one tiny api-client `get_task` call. The REST API (`/diffs/report`, `/tasks/{id}`,
+  `/diffs/{id}` with `available_reports`) and report storage are unchanged — they already work.
+- **DEC-2** Live view serves the report **inline** by re-serving the bytes the API already
+  returns, with `Content-Disposition: inline` and the report's media type. No new API endpoint.
+- **DEC-3** Completion is detected by **client-side polling** of a same-origin
+  `GET /tasks/{id}/status` UI proxy (3s interval, bounded). Polling, not websockets — lazy,
+  no new dependency, matches the existing httpx/SSR stack.
+- **DEC-4** Inline view serves the **single built file**. Self-contained HTML confirmed; if a
+  future template emits external local assets, escalate to serving the report directory.
+
+## Rabbit-holes (avoid)
+
+- WebSockets / SSE / a task-event bus for push completion. Polling is enough.
+- A bundled in-app report viewer/renderer. The browser renders the served file; don't rebuild
+  a viewer.
+- Reworking report storage layout or the eds4jinja2 build. Out of scope.
+
+## No-gos (explicitly out of scope)
+
+- Changing the REST API contract or the Celery task signatures.
+- Auth/access control on report URLs (same posture as today).
+- The active-tasks page redesign (task↔report correlation there is a separate, smaller follow-up).

--- a/openspec/changes/report-delivery-ux/specs/report-delivery/spec.md
+++ b/openspec/changes/report-delivery-ux/specs/report-delivery/spec.md
@@ -1,0 +1,65 @@
+# report-delivery
+
+Cites EPIC: report-delivery-ux. Restores the report delivery loop (regression after 2.2.0).
+
+## ADDED Requirements
+
+### Requirement: Built reports can be viewed live
+
+The UI SHALL serve a built report inline so the browser renders it — HTML as a page, JSON and
+ASCII as readable text — without forcing a download.
+
+#### Scenario: View an HTML report live
+
+- **GIVEN** a dataset with a built `html` report for an application profile
+- **WHEN** the user opens the report's **View** action
+- **THEN** the UI SHALL respond with the report content and an inline content disposition
+- **AND** the browser SHALL render the report as a page (not download it)
+
+#### Scenario: View a report that does not exist
+
+- **GIVEN** no report exists for the requested dataset/profile/type
+- **WHEN** the user opens the View action
+- **THEN** the UI SHALL show a clear message and redirect rather than error
+
+### Requirement: The user is told when a report build completes
+
+When a report build is triggered, the dataset view SHALL reflect that a build is in progress
+and SHALL reveal the finished report without requiring a manual page refresh.
+
+#### Scenario: Build then completion
+
+- **GIVEN** the user triggers a report build on the dataset view
+- **WHEN** the build task is still running
+- **THEN** the view SHALL show a "building" indicator for that application profile and type
+- **AND** when the task reaches a successful terminal state the view SHALL present the report as
+  ready to view or download
+
+#### Scenario: Build fails
+
+- **GIVEN** a triggered report build whose task fails
+- **WHEN** the dataset view detects the failed terminal state
+- **THEN** it SHALL show an error indication instead of an indefinite "building" state
+
+### Requirement: Built reports remain downloadable per variant
+
+The dataset view SHALL list every built report grouped by application profile and template
+type, each offering a download.
+
+#### Scenario: Download a built report variant
+
+- **GIVEN** a dataset with one or more built reports
+- **WHEN** the user views the dataset
+- **THEN** each built application-profile/template-type variant SHALL be listed with a download
+  action that streams the report as an attachment
+
+### Requirement: Completion polling is bounded
+
+The completion indicator SHALL poll a same-origin task-status endpoint at a fixed interval and
+SHALL stop on a terminal state or after a bounded number of attempts.
+
+#### Scenario: Task never resolves
+
+- **GIVEN** a build whose task never reaches a terminal state
+- **WHEN** the bounded number of poll attempts is exhausted
+- **THEN** the view SHALL stop polling and prompt the user to refresh later

--- a/openspec/changes/report-delivery-ux/tasks.md
+++ b/openspec/changes/report-delivery-ux/tasks.md
@@ -1,0 +1,24 @@
+# PLAN — tasks (EPIC: report-delivery-ux)
+
+Golden thread: restores the report build→discover→serve loop lost in the 2.2.0 FastAPI rewrite.
+
+## T1 — api-client
+- [ ] T1.1 Add `get_task(task_id) -> ApiResult` (GET `/tasks/{task_id}`).
+
+## T2 — UI routes (`ui/routes.py`)
+- [ ] T2.1 `build_report`: thread the API `task_id` into a redirect `?building=&ap=&tt=`.
+- [ ] T2.2 `view_dataset`: accept optional `building`/`ap`/`tt`, pass to template.
+- [ ] T2.3 New `task_status` proxy route `GET /tasks/{id}/status` → JSON `{status}`.
+- [ ] T2.4 New `view_report` route serving the report **inline** (HTML renders, JSON/ASCII shown).
+
+## T3 — Templates (`dataset/view_dataset.html`)
+- [ ] T3.1 Per-variant **View** (new tab) + **Download** actions in the available-reports list.
+- [ ] T3.2 Building banner + dependency-free bounded poller that refreshes on completion.
+
+## T4 — Tests
+- [ ] T4.1 Unit: build redirect carries building params; view renders banner; status proxy; inline view; list links. (TDD)
+- [ ] T4.2 BDD: `tests/features/report_delivery.feature` + steps (happy, edge=build fails, negative=missing report).
+- [ ] T4.3 `make check-quality` / `check-architecture` / `test-unit` green.
+
+## T5 — Docs
+- [ ] T5.1 README: document viewing vs downloading a report and the completion behaviour.

--- a/rdf_differ/api/entrypoints/ui/api_client.py
+++ b/rdf_differ/api/entrypoints/ui/api_client.py
@@ -95,6 +95,11 @@ def revoke_task(task_id: str) -> ApiResult:
     return _request("DELETE", f"/tasks/{task_id}")
 
 
+def get_task(task_id: str) -> ApiResult:
+    """Fetch a task's state (``{task_id, status, result}``) — used by the status poller."""
+    return _request("GET", f"/tasks/{task_id}")
+
+
 def create_diff(data: dict, files: dict) -> ApiResult:
     """POST a multipart diff-creation request. ``files`` maps field -> (name, bytes, mime)."""
     return _request("POST", "/diffs", data=data, files=files)

--- a/rdf_differ/api/entrypoints/ui/routes.py
+++ b/rdf_differ/api/entrypoints/ui/routes.py
@@ -9,7 +9,7 @@ import logging
 import re
 
 from fastapi import APIRouter, File, Form, Request, UploadFile
-from fastapi.responses import RedirectResponse, Response
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from pydantic import ValidationError
 
 from rdf_differ import config
@@ -22,6 +22,7 @@ logger = logging.getLogger(config.RDF_DIFFER_LOGGER)
 router = APIRouter()
 
 _SEE_OTHER = 303
+_UNKNOWN_STATUS = "UNKNOWN"
 
 
 @router.get("/", name="index")
@@ -110,7 +111,13 @@ async def create_diff_submit(
 
 
 @router.get("/diffs/{dataset_id}", name="view_dataset")
-def view_dataset(request: Request, dataset_id: str) -> Response:
+def view_dataset(
+    request: Request,
+    dataset_id: str,
+    building: str | None = None,
+    ap: str | None = None,
+    tt: str | None = None,
+) -> Response:
     dataset_result = api_client.get_dataset(dataset_id)
     if not dataset_result.ok:
         flash(request, dataset_result.error_message(), "error")
@@ -124,6 +131,9 @@ def view_dataset(request: Request, dataset_id: str) -> Response:
         active_page="view_dataset",
         dataset=dataset_result.json,
         application_profiles=profiles,
+        building=building,
+        building_ap=ap,
+        building_tt=tt,
     )
 
 
@@ -137,13 +147,18 @@ def build_report(
 ) -> Response:
     validate_csrf(request, csrf_token)
     result = api_client.build_report(dataset_id, application_profile, template_type)
-    if result.ok:
-        flash(request, "Report building started.", "success")
-    else:
+    if not result.ok:
         flash(request, result.error_message(), "error")
-    return RedirectResponse(
-        request.url_for("view_dataset", dataset_id=dataset_id), status_code=_SEE_OTHER
+        return RedirectResponse(
+            request.url_for("view_dataset", dataset_id=dataset_id), status_code=_SEE_OTHER
+        )
+
+    flash(request, "Report building started.", "success")
+    task_id = (result.json or {}).get("task_id")
+    target = request.url_for("view_dataset", dataset_id=dataset_id).include_query_params(
+        building=task_id, ap=application_profile, tt=template_type
     )
+    return RedirectResponse(target, status_code=_SEE_OTHER)
 
 
 @router.get(
@@ -166,6 +181,37 @@ def download_report(
         media_type=response.headers.get("content-type", "application/octet-stream"),
         headers={"content-disposition": f'attachment; filename="{filename}"'},
     )
+
+
+@router.get(
+    "/diff-report/{dataset_id}/{application_profile}/{template_type}/view", name="view_report"
+)
+def view_report(
+    request: Request, dataset_id: str, application_profile: str, template_type: str
+) -> Response:
+    """Serve a built report inline so the browser renders it (HTML/JSON/ASCII) live."""
+    response = api_client.get_report(dataset_id, application_profile, template_type)
+    if response.status_code != 200:
+        flash(request, "Could not open the report. Build it first.", "error")
+        return RedirectResponse(request.url_for("index"), status_code=_SEE_OTHER)
+
+    return Response(
+        content=response.content,
+        media_type=response.headers.get("content-type", "text/html"),
+        headers={"content-disposition": "inline"},
+    )
+
+
+@router.get("/tasks/{task_id}/status", name="task_status")
+def task_status(request: Request, task_id: str) -> JSONResponse:
+    """Proxy the upstream task status for the dataset-view poller.
+
+    Always returns 200 with a status string so the client poller degrades gracefully
+    (a sentinel ``UNKNOWN``) instead of seeing a 5xx and giving up.
+    """
+    result = api_client.get_task(task_id)
+    status = (result.json or {}).get("status", _UNKNOWN_STATUS) if result.ok else _UNKNOWN_STATUS
+    return JSONResponse({"status": status})
 
 
 @router.get("/tasks", name="get_active_tasks")

--- a/rdf_differ/api/entrypoints/ui/templates/dataset/view_dataset.html
+++ b/rdf_differ/api/entrypoints/ui/templates/dataset/view_dataset.html
@@ -10,6 +10,56 @@
         <a class="link" href="{{ url_for('index') }}">← Back to diffs</a>
     </div>
 
+    {% if building %}
+        <div class="card" id="building-banner" role="status">
+            <p id="building-banner-text">⏳ Building {{ building_ap }} · {{ building_tt }} report…</p>
+        </div>
+
+        <script>
+            (function () {
+                const statusUrl = "{{ url_for('task_status', task_id=building) }}";
+                const doneUrl = "{{ url_for('view_dataset', dataset_id=dataset.uid) }}";
+                const banner = document.getElementById('building-banner-text');
+                const intervalMs = 3000;
+                const maxAttempts = 100;
+                let attempts = 0;
+                let timer = null;
+
+                function stop() {
+                    if (timer !== null) {
+                        clearInterval(timer);
+                        timer = null;
+                    }
+                }
+
+                function poll() {
+                    attempts += 1;
+                    if (attempts > maxAttempts) {
+                        stop();
+                        banner.textContent = 'Still building — refresh later to see the report.';
+                        return;
+                    }
+                    fetch(statusUrl)
+                        .then(function (response) { return response.json(); })
+                        .then(function (data) {
+                            const status = (data && data.status) || '';
+                            if (status === 'SUCCESS') {
+                                stop();
+                                window.location.replace(doneUrl);
+                            } else if (status === 'FAILURE' || status === 'FAILED' || status === 'ERROR') {
+                                stop();
+                                banner.textContent = '⚠ The report build failed. Please try again.';
+                            }
+                        })
+                        .catch(function () { /* transient error — keep polling */ });
+                }
+
+                timer = setInterval(poll, intervalMs);
+                poll();
+            })();
+        </script>
+    {% endif %}
+
     <div class="card">
         <table class="detail-table">
             <tbody>
@@ -33,6 +83,12 @@
                 <ul class="report-list">
                     {% for variant in report.template_variations %}
                         <li>
+                            <a class="link"
+                               id="report-view-{{ dataset.uid }}-{{ report.application_profile }}-{{ variant }}"
+                               target="_blank"
+                               href="{{ url_for('view_report', dataset_id=dataset.uid, application_profile=report.application_profile, template_type=variant) }}">
+                                View {{ report.application_profile }} · {{ variant }}
+                            </a>
                             <a class="link"
                                id="report-{{ dataset.uid }}-{{ report.application_profile }}-{{ variant }}"
                                href="{{ url_for('download_report', dataset_id=dataset.uid, application_profile=report.application_profile, template_type=variant) }}">

--- a/tests/feature/test_report_delivery_steps.py
+++ b/tests/feature/test_report_delivery_steps.py
@@ -1,0 +1,175 @@
+"""Steps for report_delivery.feature — viewing, downloading and tracking reports.
+
+Infra-free: FastAPI TestClient with the httpx api_client mocked, mirroring
+test_web_ui_steps.py.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from bs4 import BeautifulSoup
+from fastapi.testclient import TestClient
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from rdf_differ.api.entrypoints.ui import api_client
+from rdf_differ.api.entrypoints.ui.app import app
+
+scenarios("report_delivery.feature")
+
+CLIENT = "rdf_differ.api.entrypoints.ui.api_client"
+
+
+def _ok(json):
+    return api_client.ApiResult(status_code=200, json=json, text="")
+
+
+@pytest.fixture
+def ctx():
+    stack = ExitStack()
+    client = TestClient(app)
+    state = {"client": client, "stack": stack, "response": None}
+    yield state
+    stack.close()
+
+
+def _patch(ctx, name, **kwargs):
+    ctx["stack"].enter_context(patch(f"{CLIENT}.{name}", **kwargs))
+
+
+def _csrf(ctx):
+    page = ctx["client"].get("/create-diff")
+    return BeautifulSoup(page.text, "html.parser").find("input", {"name": "csrf_token"})["value"]
+
+
+# --- Given -------------------------------------------------------------------
+
+
+@given(
+    parsers.parse('a dataset with a built "{template_type}" report for profile "{profile}"'),
+    target_fixture="report",
+)
+def _built_report(ctx, template_type, profile):
+    response = httpx.Response(
+        200,
+        content=b"<html>report</html>",
+        headers={
+            "content-type": "text/html; charset=utf-8",
+            "content-disposition": 'attachment; filename="diff.html"',
+        },
+        request=httpx.Request("GET", "http://api/diffs/report"),
+    )
+    _patch(ctx, "get_report", return_value=response)
+    return {"dataset_id": "ds", "profile": profile, "template_type": template_type}
+
+
+@given("the API accepts a report build and returns a task id")
+def _api_accepts_build(ctx):
+    _patch(ctx, "build_report", return_value=_ok({"task_id": "task-1"}))
+
+
+@given("a report build task that has completed successfully")
+def _task_success(ctx):
+    _patch(ctx, "get_task", return_value=_ok({"task_id": "task-1", "status": "SUCCESS"}))
+
+
+@given("a report build task that has failed")
+def _task_failed(ctx):
+    _patch(ctx, "get_task", return_value=_ok({"task_id": "task-1", "status": "FAILURE"}))
+
+
+@given("no report exists for the requested dataset, profile and type", target_fixture="report")
+def _no_report(ctx):
+    response = httpx.Response(404, request=httpx.Request("GET", "http://api/diffs/report"))
+    _patch(ctx, "get_report", return_value=response)
+    _patch(ctx, "get_datasets", return_value=_ok([]))
+    return {"dataset_id": "ds", "profile": "skos-core-en-only", "template_type": "html"}
+
+
+# --- When --------------------------------------------------------------------
+
+
+@when("I open the View action for that report")
+def _open_view(ctx, report):
+    ctx["response"] = ctx["client"].get(
+        f"/diff-report/{report['dataset_id']}/{report['profile']}/{report['template_type']}/view"
+    )
+
+
+@when("I open the Download action for that report")
+def _open_download(ctx, report):
+    ctx["response"] = ctx["client"].get(
+        f"/diff-report/{report['dataset_id']}/{report['profile']}/{report['template_type']}"
+    )
+
+
+@when(parsers.parse('I submit a report build for profile "{profile}" and type "{template_type}"'))
+def _submit_build(ctx, profile, template_type):
+    csrf = _csrf(ctx)
+    ctx["response"] = ctx["client"].post(
+        "/diffs/ds",
+        data={
+            "application_profile": profile,
+            "template_type": template_type,
+            "csrf_token": csrf,
+        },
+        follow_redirects=False,
+    )
+
+
+@when("the dataset view polls the task status")
+def _poll_status(ctx):
+    ctx["response"] = ctx["client"].get("/tasks/task-1/status")
+
+
+# --- Then --------------------------------------------------------------------
+
+
+@then("the report is served inline")
+def _served_inline(ctx):
+    assert ctx["response"].status_code == 200
+    assert "inline" in ctx["response"].headers["content-disposition"]
+
+
+@then("the response content type is for HTML")
+def _content_type_html(ctx):
+    assert ctx["response"].headers["content-type"].startswith("text/html")
+
+
+@then("the response is served as an attachment")
+def _served_attachment(ctx):
+    assert ctx["response"].status_code == 200
+    assert "attachment" in ctx["response"].headers["content-disposition"]
+
+
+@then(
+    parsers.parse(
+        'I am taken to the dataset view with a building indicator for "{profile}" · "{template_type}"'
+    )
+)
+def _redirect_with_building(ctx, profile, template_type):
+    assert ctx["response"].status_code == 303
+    query = parse_qs(urlsplit(ctx["response"].headers["location"]).query)
+    assert query["building"] == ["task-1"]
+    assert query["ap"] == [profile]
+    assert query["tt"] == [template_type]
+
+
+@then("the status endpoint reports the task as successful")
+def _status_success(ctx):
+    assert ctx["response"].status_code == 200
+    assert ctx["response"].json() == {"status": "SUCCESS"}
+
+
+@then("the status endpoint reports the task as failed")
+def _status_failed(ctx):
+    assert ctx["response"].status_code == 200
+    assert ctx["response"].json() == {"status": "FAILURE"}
+
+
+@then("I am redirected with a clear message instead of an error")
+def _redirect_with_message(ctx):
+    assert ctx["response"].status_code == 200  # followed redirect to index
+    assert "Could not open the report" in ctx["response"].text

--- a/tests/features/report_delivery.feature
+++ b/tests/features/report_delivery.feature
@@ -1,0 +1,35 @@
+Feature: Report delivery in the web UI
+  As a user of the RDF Differ web UI
+  I want to build a report, know when it is ready, and view or download it
+  So that I can actually obtain the diff report without guessing when it finished.
+
+  Scenario: A built report can be viewed live in the browser
+    Given a dataset with a built "html" report for profile "skos-core-en-only"
+    When I open the View action for that report
+    Then the report is served inline
+    And the response content type is for HTML
+
+  Scenario: A built report can be downloaded as a file
+    Given a dataset with a built "html" report for profile "skos-core-en-only"
+    When I open the Download action for that report
+    Then the response is served as an attachment
+
+  Scenario: Building a report shows a progress indicator on the dataset view
+    Given the API accepts a report build and returns a task id
+    When I submit a report build for profile "skos-core-en-only" and type "html"
+    Then I am taken to the dataset view with a building indicator for "skos-core-en-only" · "html"
+
+  Scenario: A completed build is reported as ready
+    Given a report build task that has completed successfully
+    When the dataset view polls the task status
+    Then the status endpoint reports the task as successful
+
+  Scenario: A failed build is reported as failed, not stuck building
+    Given a report build task that has failed
+    When the dataset view polls the task status
+    Then the status endpoint reports the task as failed
+
+  Scenario: Viewing a report that was never built is handled gracefully
+    Given no report exists for the requested dataset, profile and type
+    When I open the View action for that report
+    Then I am redirected with a clear message instead of an error

--- a/tests/unit/test_ui_report_delivery.py
+++ b/tests/unit/test_ui_report_delivery.py
@@ -1,0 +1,179 @@
+"""Unit tests for the report-delivery-ux UI restoration.
+
+Covers the new ``view_report`` (inline) and ``task_status`` (status proxy) routes,
+the building-banner + poller markup on the dataset view, the View/Download action
+pair in the available-reports list, and the build redirect threading the task id.
+
+The httpx api_client is mocked; the TestClient does not follow redirects where the
+redirect Location itself is the assertion target.
+"""
+
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from bs4 import BeautifulSoup
+from fastapi.testclient import TestClient
+
+from rdf_differ.api.entrypoints.ui import api_client
+from rdf_differ.api.entrypoints.ui.app import app
+
+CLIENT = "rdf_differ.api.entrypoints.ui.api_client"
+
+
+@pytest.fixture
+def ui():
+    return TestClient(app)
+
+
+@pytest.fixture
+def csrf(ui):
+    page = ui.get("/create-diff")
+    return BeautifulSoup(page.text, "html.parser").find("input", {"name": "csrf_token"})["value"]
+
+
+def _ok(json):
+    return api_client.ApiResult(status_code=200, json=json, text="")
+
+
+def _err(status, detail, title="Conflict"):
+    return api_client.ApiResult(
+        status_code=status, json={"status": status, "title": title, "detail": detail}, text=""
+    )
+
+
+def _dataset(uid="uid", reports=None):
+    return {
+        "uid": uid,
+        "dataset_name": "dataset_one123456",
+        "original_name": "dataset_one",
+        "dataset_description": "dataset_one is a dataset",
+        "dataset_uri": "http://dataset.one",
+        "old_version_file": "one_old.ttl",
+        "new_version_file": "one_new.ttl",
+        "dataset_versions": ["one_old", "one_new"],
+        "version_named_graphs": ["http://one.version/one_old", "http://one.version/one_new"],
+        "diff_date": "2020",
+        "available_reports": reports if reports is not None else [],
+    }
+
+
+# --- build_report threads the task id into the redirect -----------------------
+
+
+def test_build_report_success_redirect_carries_building_params(ui, csrf):
+    with patch(f"{CLIENT}.build_report", return_value=_ok({"task_id": "t1"})):
+        resp = ui.post(
+            "/diffs/uid",
+            data={"application_profile": "skos", "template_type": "html", "csrf_token": csrf},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    location = resp.headers["location"]
+    query = parse_qs(urlsplit(location).query)
+    assert query["building"] == ["t1"]
+    assert query["ap"] == ["skos"]
+    assert query["tt"] == ["html"]
+
+
+# --- view_dataset renders the building banner + poller -----------------------
+
+
+def test_view_dataset_with_building_renders_banner_and_poller(ui):
+    with (
+        patch(f"{CLIENT}.get_dataset", return_value=_ok(_dataset())),
+        patch(f"{CLIENT}.get_application_profiles", return_value=_ok([])),
+    ):
+        resp = ui.get("/diffs/uid?building=TASK&ap=skos&tt=html")
+
+    assert resp.status_code == 200
+    assert "Building" in resp.text
+    assert "skos" in resp.text
+    # The poller fetches the status endpoint for this task.
+    assert "/tasks/TASK/status" in resp.text
+
+
+def test_view_dataset_without_building_has_no_banner(ui):
+    with (
+        patch(f"{CLIENT}.get_dataset", return_value=_ok(_dataset())),
+        patch(f"{CLIENT}.get_application_profiles", return_value=_ok([])),
+    ):
+        resp = ui.get("/diffs/uid")
+
+    assert resp.status_code == 200
+    assert "/status" not in resp.text
+
+
+# --- task_status proxy -------------------------------------------------------
+
+
+def test_task_status_returns_upstream_status(ui):
+    with patch(f"{CLIENT}.get_task", return_value=_ok({"task_id": "t1", "status": "SUCCESS"})):
+        resp = ui.get("/tasks/t1/status")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "SUCCESS"}
+
+
+def test_task_status_degrades_to_sentinel_on_api_error(ui):
+    with patch(f"{CLIENT}.get_task", return_value=_err(503, "no api")):
+        resp = ui.get("/tasks/t1/status")
+
+    # Never 500 — the poller must keep degrading gracefully.
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "UNKNOWN"}
+
+
+# --- view_report serves inline -----------------------------------------------
+
+
+def test_view_report_serves_inline_with_upstream_media_type(ui):
+    response = httpx.Response(
+        200,
+        content=b"<html>report</html>",
+        headers={"content-type": "text/html; charset=utf-8"},
+        request=httpx.Request("GET", "http://api/diffs/report"),
+    )
+    with patch(f"{CLIENT}.get_report", return_value=response):
+        resp = ui.get("/diff-report/ds/ap/html/view")
+
+    assert resp.status_code == 200
+    assert resp.content == b"<html>report</html>"
+    assert "inline" in resp.headers["content-disposition"]
+    assert resp.headers["content-type"].startswith("text/html")
+
+
+def test_view_report_missing_flashes_and_redirects(ui):
+    response = httpx.Response(404, request=httpx.Request("GET", "http://api/diffs/report"))
+    with (
+        patch(f"{CLIENT}.get_report", return_value=response),
+        patch(f"{CLIENT}.get_datasets", return_value=_ok([])),
+    ):
+        resp = ui.get("/diff-report/ds/ap/html/view")
+
+    assert resp.status_code == 200  # followed redirect to index
+    assert "Could not open the report" in resp.text
+
+
+# --- available-reports list renders both View and Download -------------------
+
+
+def test_available_reports_list_renders_view_and_download(ui):
+    reports = [{"application_profile": "skos", "template_variations": ["html"]}]
+    with (
+        patch(f"{CLIENT}.get_dataset", return_value=_ok(_dataset(reports=reports))),
+        patch(f"{CLIENT}.get_application_profiles", return_value=_ok([])),
+    ):
+        resp = ui.get("/diffs/uid")
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.text, "html.parser")
+    download = soup.find(id="report-uid-skos-html")
+    view = soup.find(id="report-view-uid-skos-html")
+    assert download is not None
+    assert "/diff-report/uid/skos/html" in download["href"]
+    assert view is not None
+    assert view["href"].endswith("/diff-report/uid/skos/html/view")
+    assert view.get("target") == "_blank"


### PR DESCRIPTION
Fixes the reported regression: after building a diff report there was no signal when it was ready (the freshly-built report only appeared on a manual refresh), and no way to view it live — it read as "the software does not deliver the basic functionality".

Shaped as `openspec/changes/report-delivery-ux/` (EPIC + PLAN + spec + `tests/features/report_delivery.feature`).

## What changed (UI layer only — REST API, Celery, report storage untouched)
- **Serve/view live (the preferred option):** new `view_report` route serves a built report **inline** so the browser renders it — HTML as a page, JSON/ASCII as text. (HTML reports are self-contained: inline `<style>`, only remote/CDN refs.)
- **Completion signal:** `build_report` threads the API `task_id` into the dataset-view redirect; the view shows a "⏳ Building <ap> · <type>…" banner and a dependency-free **bounded poller** that hits a same-origin `/tasks/{id}/status` proxy, then reveals the report on `SUCCESS` (no manual refresh) or shows an error on failure.
- **Download list kept:** each report variant now offers both **View** (new tab) and **Download**.
- `api_client.get_task` + the `task_status` proxy.

## Why this is the right fix (2.1.0 check)
2.1.0's `download_report` also forced `as_attachment` — what "worked well" then was discoverability (documented build→list→download). The rewrite kept the download route but dropped completion feedback. This restores the loop and adds live serving.

## Verification
`make check-quality` · `make check-architecture` 10/10 · unit **344 passed** (8 new) · feature **37 passed** (6 new BDD scenarios). Tests stub the api_client at the UI boundary.

> Recommend a manual smoke test against a live stack (build → banner → auto-reveal → View renders HTML) since automated coverage is at the UI boundary.