### PR TITLE
chore(test): retire start-services-test — self-sufficient stack + self-provisioning tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ TRAEFIK      = docker compose -p common --file ./infra/traefik/docker-compose.ym
         test test-unit test-feature \
         start stop status start-services-test teardown-services \
         local-deps local-fuseki-setup local-fuseki local-api local-ui local-redis local-stop \
-        generate-models set-report-template run-dev-ui \
-        _test-data-fuseki
+        generate-models set-report-template run-dev-ui
 
 help:
 	@ echo "RDF Differ — make targets:"
@@ -111,7 +110,7 @@ test-feature:
 
 test:
 	@ echo "$(BUILD_PRINT)Running the full suite with coverage"
-	@ echo "$(MSG_PRINT)Needs the stack — run 'make start-services-test' first if it isn't up."
+	@ echo "$(MSG_PRINT)Needs the stack — 'make start-services-test' (or 'docker compose -f infra/docker-compose-tests.yml up -d --wait') first."
 	@ poetry run pytest --cov=rdf_differ --cov-report=term-missing --cov-report=xml
 
 #-----------------------------------------------------------------------------
@@ -136,26 +135,17 @@ stop:
 	@ $(TRAEFIK) down
 	@ echo "$(MSG_PRINT)Stopped. Restart with: make start"
 
-# CI/e2e test stack — one compose up brings up every test service (build on demand).
+# CI/e2e test stack — a plain `compose up --wait` is enough: the compose file declares
+# its own network + volume and healthchecks, and tests self-provision their datasets
+# (no network/volume pre-create, no sleep, no dataset seeding). Then: `pytest -m integration`.
 start-services-test:
-	@ echo "$(BUILD_PRINT)Bringing up the test stack (fuseki, redis, celery, api)"
-	@ docker network create proxy-net || true
-	@ docker volume create rdf-differ-template-$(ENVIRONMENT)
-	@ $(COMPOSE_TEST) up -d --build \
+	@ echo "$(BUILD_PRINT)Bringing up the test stack (waits for healthchecks)"
+	@ $(COMPOSE_TEST) up -d --build --wait \
 		rdf-differ-fuseki rdf-differ-redis rdf-differ-celery-worker rdf-differ-api
-	@ echo "$(BUILD_PRINT)Waiting 5s for services to stabilise"
-	@ sleep 5
-	@ $(MAKE) _test-data-fuseki
 
 teardown-services:
 	@ echo "$(BUILD_PRINT)Tearing down the stack (containers + volumes)"
 	@ $(COMPOSE_TEST) down --volumes --remove-orphans
-
-_test-data-fuseki:
-	@ echo "$(BUILD_PRINT)Creating dummy 'subdiv' and 'abc' test datasets on Fuseki :$(RDF_DIFFER_FUSEKI_PORT)"
-	@ sleep 5
-	@ curl --anyauth --user 'admin:admin' -d 'dbType=mem&dbName=subdiv' 'http://localhost:$(RDF_DIFFER_FUSEKI_PORT)/$$/datasets'
-	@ curl --anyauth --user 'admin:admin' -d 'dbType=mem&dbName=abc'    'http://localhost:$(RDF_DIFFER_FUSEKI_PORT)/$$/datasets'
 
 #-----------------------------------------------------------------------------
 # Local services (no Docker) — run each in its own shell

--- a/infra/docker-compose-tests.yml
+++ b/infra/docker-compose-tests.yml
@@ -14,7 +14,17 @@ services:
     networks:
       - mydefault
     depends_on:
-      - rdf-differ-redis
+      rdf-differ-redis:
+        condition: service_healthy
+      rdf-differ-fuseki:
+        condition: service_healthy
+    # `docker compose up --wait` blocks until this is healthy — replaces the manual `sleep`.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:${RDF_DIFFER_API_PORT}/diffs"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
 
   rdf-differ-ui:
     container_name: rdf-differ-ui-${ENVIRONMENT}
@@ -42,6 +52,12 @@ services:
       - ${RDF_DIFFER_FUSEKI_PORT}:${RDF_DIFFER_FUSEKI_PORT}
     networks:
       - mydefault
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:${RDF_DIFFER_FUSEKI_PORT}/$$/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
 
   rdf-differ-celery-worker:
     container_name: rdf-differ-celery-worker-${ENVIRONMENT}
@@ -56,8 +72,10 @@ services:
     networks:
       - mydefault
     depends_on:
-      - rdf-differ-api
-      - rdf-differ-redis
+      rdf-differ-redis:
+        condition: service_healthy
+      rdf-differ-fuseki:
+        condition: service_healthy
 
   rdf-differ-redis:
     image: redis:6-alpine
@@ -66,6 +84,11 @@ services:
       - ${RDF_DIFFER_REDIS_PORT}:${RDF_DIFFER_REDIS_PORT}
     networks:
       - mydefault
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   rdf-differ-flower:
     container_name: rdf-differ-flower-${ENVIRONMENT}
@@ -83,8 +106,8 @@ services:
       - mydefault
 
 volumes:
+  # Auto-created by compose (was external:true, which forced a manual `docker volume create`).
   rdf-differ-template:
-    external: true
 
 
 networks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,19 @@
 # Author: Mihai Coșleț
 # Email: coslet.mihai@gmail.com
 
+import contextlib
 from collections import namedtuple
 from io import BytesIO
 
 import pytest
+import requests
 from werkzeug.datastructures import FileStorage
 
+from rdf_differ import config
 from rdf_differ.api.entrypoints.ui import app as ui_app
+from rdf_differ.core.adapters.sparql import SPARQLRunner
 from rdf_differ.diffing.adapters.diff_adapter import FusekiDiffAdapter
+from rdf_differ.diffing.adapters.exceptions import FusekiException
 from rdf_differ.diffing.adapters.skos_history_wrapper import SKOSHistoryRunner
 
 
@@ -114,6 +119,42 @@ def ui_client():
     from fastapi.testclient import TestClient
 
     return TestClient(ui_app)
+
+
+@pytest.fixture
+def live_fuseki() -> str:
+    """Skip the test unless a live Fuseki is reachable.
+
+    Lets service-dependent tests run against a plain ``docker compose up`` stack and
+    skip cleanly otherwise — no special bring-up target needed.
+    """
+    base = config.RDF_DIFFER_FUSEKI_SERVICE
+    try:
+        response = requests.get(f"{base}/$/ping", timeout=2)
+    except requests.RequestException:
+        pytest.skip("Fuseki is not reachable")
+    if response.status_code != 200:
+        pytest.skip("Fuseki is not reachable")
+    return base
+
+
+@pytest.fixture
+def subdiv_dataset(live_fuseki: str):
+    """Provision (and tear down) an empty ``subdiv`` dataset on the live Fuseki.
+
+    Replaces the old ``make _test-data-fuseki`` seeding: tests that load versions into
+    ``subdiv`` now create the dataset themselves, so the stack needs no pre-seeding.
+    """
+    adapter = FusekiDiffAdapter(
+        triplestore_service_url=config.RDF_DIFFER_FUSEKI_SERVICE,
+        http_client=requests,
+        sparql_client=SPARQLRunner(),
+    )
+    with contextlib.suppress(FusekiException):
+        adapter.create_dataset("subdiv")  # already exists is fine — the test populates it
+    yield "subdiv"
+    with contextlib.suppress(FusekiException):
+        adapter.delete_dataset("subdiv")
 
 
 def helper_create_diff(file_1=None, file_2=None, body=None):

--- a/tests/feature/test_diffing_two_dataset_versions.py
+++ b/tests/feature/test_diffing_two_dataset_versions.py
@@ -56,7 +56,7 @@ def metadata(tmpdir, files):
 
 
 @scenario("../features/diffing_two_dataset_versions.feature", "Diffing two dataset versions")
-def test_diffing_two_dataset_versions():
+def test_diffing_two_dataset_versions(subdiv_dataset):
     """Diffing two dataset versions."""
 
 

--- a/tests/feature/test_execute_skos_history.py
+++ b/tests/feature/test_execute_skos_history.py
@@ -70,7 +70,7 @@ INPUT_MIME_TYPE="application/rdf+xml"
 
 
 @scenario("../features/execute_skos_history.feature", "Running the skos-history")
-def test_running_the_skos_history():
+def test_running_the_skos_history(subdiv_dataset):
     """Running the skos-history."""
 
 

--- a/tests/unit/test_skos_history_wrapper.py
+++ b/tests/unit/test_skos_history_wrapper.py
@@ -77,7 +77,7 @@ def test_skos_history_folder_setup_basedir_exist_is_not_empty(tmpdir):
 
 
 @pytest.mark.integration  # needs live Fuseki/Redis/db (not a unit test)
-def test_skos_history_execute_subprocess(tmpdir):
+def test_skos_history_execute_subprocess(tmpdir, subdiv_dataset):
     skos_runner = helper_create_skos_runner()
     # get absolute path as script is wonky when relative path is used
     test_data_location = Path(__file__).parent.parent / "test_data/original/subdivisions_sh_ds/data"


### PR DESCRIPTION
Makes the test stack self-sufficient so the special bring-up target is no longer needed.

- **Compose self-contained:** declares its own network + volume (dropped `external: true`), adds **healthchecks** (fuseki/redis/api) so `docker compose up -d --wait` blocks until ready — replacing the fixed `sleep`.
- **Tests self-provision datasets:** new `subdiv_dataset` fixture (create + teardown) and `live_fuseki` (skips when Fuseki unreachable) replace `make _test-data-fuseki`. The unused `abc` seed is gone.
- **Makefile:** `start-services-test` collapses to `compose up -d --build --wait`; `_test-data-fuseki` + vestigial `docker network create proxy-net` / `docker volume create` removed.

Flow: `docker compose -f infra/docker-compose-tests.yml up -d --wait && poetry run pytest -m integration`.

Verified: `compose config` valid · `make lint`/`check-architecture` green · unit+feature **404 passed, 5 skipped** (integration tests skip cleanly when Fuseki is down).