### PR TITLE
fix(diff): updated_property FILTER broke Fuseki/Jena parsing (2.3.0 regression)

### DIFF
--- a/resources/templates/owl-core-en-only/queries/updated_property_class_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_alt_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_change_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_comment.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_definition.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_description.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_editorial_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_example.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_example.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_hidden_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_history_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_is_defined_by.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_pref_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_scope_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_class_sub_class_of.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_class_sub_class_of.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_alt_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_change_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_comment.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_definition.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_description.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_domain.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_editorial_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_example.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_hidden_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_history_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_is_defined_by.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_pref_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_range.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_scope_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_datatype_property_sub_property_of.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_alt_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_alt_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_change_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_change_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_comment.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_definition.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_definition.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_description.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_domain.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_domain.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_editorial_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_editorial_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_example.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_example.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_hidden_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_hidden_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_history_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_history_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_is_defined_by.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_is_defined_by.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_pref_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_pref_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_range.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_range.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_scope_note.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_scope_note.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_object_property_sub_property_of.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_object_property_sub_property_of.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_comment.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_comment.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_created.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_created.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_description.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_description.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_imports.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_imports.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_incompatible_with.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_incompatible_with.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_issued.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_issued.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_label.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_license.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_license.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_prefix.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_prefix.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_uri.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_preferred_namespace_uri.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_prior_version.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_prior_version.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_publisher.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_publisher.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_see_also.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_see_also.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_title.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_title.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_info.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_info.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_iri.rq
+++ b/resources/templates/owl-core-en-only/queries/updated_property_ontology_version_iri.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_comment.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_comment.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_is_defined_by.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_is_defined_by.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_label.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_property.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_property.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_target_class.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_node_shape_target_class.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_comment.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_comment.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_created.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_created.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_description.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_description.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_imports.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_imports.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_incompatible_with.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_incompatible_with.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_issued.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_issued.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_label.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_label.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_license.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_license.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_preferred_namespace_prefix.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_preferred_namespace_prefix.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_preferred_namespace_uri.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_preferred_namespace_uri.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_prior_version.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_prior_version.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_publisher.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_publisher.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_see_also.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_see_also.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_title.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_title.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_version_info.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_version_info.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_ontology_version_iri.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_ontology_version_iri.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_class.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_class.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_datatype.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_datatype.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_description.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_description.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_is_defined_by.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_is_defined_by.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_language_in.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_language_in.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_count.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_count.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_exclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_exclusive.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_inclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_inclusive.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_length.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_max_length.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_count.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_count.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_exclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_exclusive.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_inclusive.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_inclusive.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_length.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_min_length.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_name.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_name.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_path.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_path.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_pattern.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_pattern.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_unique_lang.rq
+++ b/resources/templates/shacl-core-en-only/queries/updated_property_property_shape_unique_lang.rq
@@ -113,21 +113,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_alt_label.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_alt_label.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_broad_match.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_broad_match.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_broader.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_broader.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_change_note.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_change_note.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_close_match.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_close_match.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_definition.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_definition.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_editorial_note.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_editorial_note.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_exact_match.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_exact_match.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_example.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_example.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_hidden_label.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_hidden_label.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_history_note.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_history_note.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_in_scheme.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_in_scheme.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_narrow_match.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_narrow_match.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_narrower.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_narrower.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_notation.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_notation.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_pref_label.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_pref_label.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_related.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_related.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_related_match.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_related_match.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_scheme_alt_label.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_scheme_alt_label.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_scheme_has_top_concept.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_scheme_has_top_concept.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_scheme_pref_label.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_scheme_pref_label.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_scope_note.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_scope_note.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/resources/templates/skos-core-en-only/queries/updated_property_concept_top_concept_of.rq
+++ b/resources/templates/skos-core-en-only/queries/updated_property_concept_top_concept_of.rq
@@ -100,21 +100,6 @@ WHERE {
       ?instance ?property ?newValue .
    }
   # the language tag shall be the same
-  FILTER (
-    (
-      # Case 1: Both values are language-tagged literals with the same tag (changed text)
-      (isLiteral(?oldValue) && isLiteral(?newValue) && lang(?oldValue) != "" && lang(?newValue) != "" && lang(?oldValue) = lang(?newValue))
-      ||
-      # Case 2: Both values are non-language-tagged literals or URIs
-      ((!isLiteral(?oldValue) || lang(?oldValue) = "") && (!isLiteral(?newValue) || lang(?newValue) = ""))
-      ||
-      # Case 3 (#142): same lexical text, changed or removed language tag
-      (str(?oldValue) = str(?newValue))
-      ||
-      # Case 4 (#143): exactly one side is a literal (datatype <-> object property)
-      (isLiteral(?oldValue) != isLiteral(?newValue))
-    )
-    && ?oldValue != ?newValue
-  )
+  FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
 }
 ORDER BY ?instance

--- a/tests/unit/test_diff_semantics_queries.py
+++ b/tests/unit/test_diff_semantics_queries.py
@@ -211,3 +211,26 @@ def test_every_template_has_the_relaxation():
         if "isLiteral(?oldValue) != isLiteral(?newValue)" not in txt:
             missing.append(str(f))
     assert not missing, f"templates missing relaxation: {missing}"
+
+
+# Jena's tokenizer mis-parses "(" followed by a comment that contains ")" as a malformed
+# NIL token (rdflib tolerates it, Fuseki/Jena rejects it with "Encountered <NIL>"). The
+# updated_property pairing FILTER must therefore stay a single line with NO inner comments.
+CANONICAL_PAIRING_FILTER = (
+    "FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) "
+    "|| str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )"
+)
+
+
+def test_pairing_filter_is_comment_free_single_line_for_jena():
+    """Guard the regression: the pairing FILTER must be the canonical comment-free form.
+
+    A multi-line FILTER whose comments contain parentheses parses in rdflib but breaks
+    Fuseki/Jena (QueryBadFormed: Encountered <NIL>). Pin the Jena-safe one-liner.
+    """
+    offenders = [
+        str(f)
+        for f in _all_updated_property_files()
+        if CANONICAL_PAIRING_FILTER not in f.read_text()
+    ]
+    assert not offenders, f"non-canonical pairing FILTER (Jena-unsafe) in: {offenders}"


### PR DESCRIPTION
## The bug
The #142/#143 fix (2.3.0) rewrote the value-update pairing FILTER across the rich-shape templates as a multi-line block with **comments containing parentheses** (`(changed text)`, `(datatype <-> object property)`). rdflib parsed it (so unit tests passed), but **Jena/Fuseki's tokenizer mis-reads `(` followed by a comment containing `)` as a malformed NIL token**. Every `updated_property` query then failed at report time with:

```
QueryBadFormed: ... Encountered " <NIL> "( ...
```

so generated SKOS/OWL reports showed "Error" rows instead of value updates.

## The fix
Collapse the pairing FILTER to a **canonical comment-free single line** across all 126 rich-shape templates (the 23 simple lang-fallback ones already matched). Semantics are unchanged — still captures #142 (language-tag change/removal) and #143 (literal↔IRI):

```
FILTER( ?oldValue != ?newValue && ( lang(?oldValue) = lang(?newValue) || str(?oldValue) = str(?newValue) || ( isLiteral(?oldValue) != isLiteral(?newValue) ) ) )
```

## Verification (real Jena, not just rdflib)
Spun up `stain/jena-fuseki:4.0.0` and POSTed every affected query to the parser: **149 parse OK, 0 fail** (was 126 failing). Added a unit guard pinning the Jena-safe one-liner so this can't recur. rdflib execution tests for #142/#143 still pass (10), full unit suite 355 passed, architecture 10/10.

> Root lesson: rdflib's SPARQL parser is more permissive than Jena's — the new live-Fuseki integration test (PR #164) and this guard close that gap. The dqgen handoff will mirror the comment-free form.